### PR TITLE
Revert "Add LeftPad"

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -498,7 +498,6 @@
   "https://github.com/davedelong/DDMathParser.git",
   "https://github.com/davedelong/time.git",
   "https://github.com/davedufresne/SwiftParsec.git",
-  "https://github.com/daveverwer/LeftPad.git",
   "https://github.com/DaveWoodCom/XCGLogger.git",
   "https://github.com/davidahouse/xcresultkit.git",
   "https://github.com/davidask/Futures.git",


### PR DESCRIPTION
This reverts commit 168c0210ff817267ae15ab0c7934a34186443d99.

## Checklist

I have either:

* [x] Run `swift ./validate.swift diff` before submitting this PR

Or, checked that:

* [ ] My repositories are publicly accessible
* [ ] My packages contain a `Package.swift` file in the root folder
* [ ] My packages are written in Swift 4.0 or later
* [ ] My package creates at least one product (library or executable)
* [ ] My package has at least one release using a git tag conforming to the [semantic version](https://semver.org/) spec. (It can be beta or pre-release)
* [ ] My package outputs valid JSON from `swift package dump-package` with the latest Swift toolchain
* [ ] My package URLs are fully specified including `https` and the `.git` extension
* [ ] My package compiles without errors
