### PR TITLE
Fix PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 I have either:
 
-* [ ] Run `./validate diff` before submitting this pull request.
+* [ ] Run `./validate.swift diff` before submitting this pull request.
 
 Or, checked that:
 


### PR DESCRIPTION
The suggested command `./validate diff` in the PR template didn't work for me. Using `./validate.swift diff` instead works fine.

```
$ ./validate diff
-bash: ./validate: No such file or directory

$ ./validate.swift diff
Checking all urls are valid.
Checking for duplicate packages.
Checking packages are sorted.
Checking each url for valid package dump.
Checking 0 Packages...
Validation Succeeded.
```