### PR TITLE
Add LoadableImage

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -28,6 +28,7 @@
   "https://github.com/abdullahselek/SwiftyNotifications.git",
   "https://github.com/abdullahselek/TakeASelfie.git",
   "https://github.com/abeintopalo/appiconsetgen.git",
+  "https://github.com/achirkof/LoadableImage.git",
   "https://github.com/aciidb0mb3r/SwiftMQTT.git",
   "https://github.com/adam-fowler/aws-cognito-authentication.git",
   "https://github.com/adam-fowler/aws-signer.git",


### PR DESCRIPTION
## Checklist

I have either:

* [x] Run `./validate.swift diff` before submitting this pull request.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.

Validation failed because of using Swift tools version 5.3.0.
```
https://github.com/achirkof/LoadableImage.git badDump(Optional("/private/var/folders/z9/828n4f1d4gq22_6n0h939w75x5092m/T/909D071B-606B-4F59-9512-2FD2A722FC56: error: package at \'/private/var/folders/z9/828n4f1d4gq22_6n0h939w75x5092m/T/909D071B-606B-4F59-9512-2FD2A722FC56\' is using Swift tools version 5.3.0 but the installed version is 5.2.0\n"))
Validation Failed
```