### PR TITLE
Use PAT to avoid rate limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,5 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_11.4.app && xcodebuild -version
     - name: Validate JSON
       run: swift .validate.swift
+      env:
+        GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
     - name: Validate JSON
       run: swift .validate.swift
       env:
-        GH_API_TOKEN_BASE64: ${{ secrets.GH_API_TOKEN_BASE64 }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
     - name: Validate JSON
       run: swift .validate.swift
       env:
-        GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+        GH_API_TOKEN_BASE64: ${{ secrets.GH_API_TOKEN_BASE64 }}

--- a/.validate.swift
+++ b/.validate.swift
@@ -97,6 +97,7 @@ func downloadSync(url: String, timeout: Int = 10) -> Result<Data, ValidatorError
     var request = URLRequest(url: apiURL)
     
     if let pat = personalAccessToken, apiURL.host == SourceHost.GitHub.rawValue {
+        print("Adding PAT")
         request.addValue("Bearer \(pat)", forHTTPHeaderField: "Authorization")
     }
     

--- a/.validate.swift
+++ b/.validate.swift
@@ -96,7 +96,7 @@ func downloadSync(url: String, timeout: Int = 10) -> Result<Data, ValidatorError
     
     var request = URLRequest(url: apiURL)
     
-    if let pat = personalAccessToken, apiURL.host == "api.github.com" {
+    if let pat = personalAccessToken, apiURL.host?.contains(SourceHost.GitHub.rawValue) == true {
         request.addValue("Basic \(pat)", forHTTPHeaderField: "Authorization")
     }
     

--- a/.validate.swift
+++ b/.validate.swift
@@ -10,8 +10,8 @@ let timeoutIntervalForRequest = 3000.0
 let timeoutIntervalForResource = 6000.0
 let httpMaximumConnectionsPerHost = 10
 
-// This is a GitHub Personal Access Token which is Base64 encoded
-let personalAccessToken = ProcessInfo.processInfo.environment["GH_API_TOKEN_BASE64"]
+// This is a GitHub Bearer Token which can be used to authenticate GitHub requests
+let bearerToken = ProcessInfo.processInfo.environment["GITHUB_TOKEN"]
 
 if personalAccessToken == nil {
     print("Warning: Using anonymous authentication -- may run into rate limiting issues\n")
@@ -96,10 +96,9 @@ func downloadSync(url: String, timeout: Int = 10) -> Result<Data, ValidatorError
     
     var request = URLRequest(url: apiURL)
     
-    if let pat = personalAccessToken?.trimmingCharacters(in: .whitespacesAndNewlines), apiURL.host?.contains(SourceHost.GitHub.rawValue) == true {
-        print("Adding PAT") // temp
-        print(pat.first, pat.last, ".")
-        request.addValue("Basic \(pat)", forHTTPHeaderField: "Authorization")
+    if let token = bearerToken, apiURL.host?.contains(SourceHost.GitHub.rawValue) == true {
+        print("Adding Token") // temp
+        request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
     }
     
     let task = session.dataTask(with: request) { (data, response, error) in

--- a/.validate.swift
+++ b/.validate.swift
@@ -96,7 +96,8 @@ func downloadSync(url: String, timeout: Int = 10) -> Result<Data, ValidatorError
     
     var request = URLRequest(url: apiURL)
     
-    if let pat = personalAccessToken, apiURL.host?.contains(SourceHost.GitHub.rawValue) == true {
+    if let pat = personalAccessToken?.trimmingCharacters(in: .whitespacesAndNewlines), apiURL.host?.contains(SourceHost.GitHub.rawValue) == true {
+        print("Adding PAT") // temp
         request.addValue("Basic \(pat)", forHTTPHeaderField: "Authorization")
     }
     

--- a/.validate.swift
+++ b/.validate.swift
@@ -10,7 +10,8 @@ let timeoutIntervalForRequest = 3000.0
 let timeoutIntervalForResource = 6000.0
 let httpMaximumConnectionsPerHost = 10
 
-let personalAccessToken = ProcessInfo.processInfo.environment["GH_API_TOKEN"]
+// This is a GitHub Personal Access Token which is Base64 encoded
+let personalAccessToken = ProcessInfo.processInfo.environment["GH_API_TOKEN_BASE64"]
 
 if personalAccessToken == nil {
     print("Warning: Using anonymous authentication -- may run into rate limiting issues\n")

--- a/.validate.swift
+++ b/.validate.swift
@@ -98,6 +98,7 @@ func downloadSync(url: String, timeout: Int = 10) -> Result<Data, ValidatorError
     
     if let pat = personalAccessToken?.trimmingCharacters(in: .whitespacesAndNewlines), apiURL.host?.contains(SourceHost.GitHub.rawValue) == true {
         print("Adding PAT") // temp
+        print(pat.first, pat.last, ".")
         request.addValue("Basic \(pat)", forHTTPHeaderField: "Authorization")
     }
     

--- a/.validate.swift
+++ b/.validate.swift
@@ -13,7 +13,7 @@ let httpMaximumConnectionsPerHost = 10
 // This is a GitHub Bearer Token which can be used to authenticate GitHub requests
 let bearerToken = ProcessInfo.processInfo.environment["GITHUB_TOKEN"]
 
-if personalAccessToken == nil {
+if bearerToken == nil {
     print("Warning: Using anonymous authentication -- may run into rate limiting issues\n")
 }
 

--- a/.validate.swift
+++ b/.validate.swift
@@ -10,6 +10,12 @@ let timeoutIntervalForRequest = 3000.0
 let timeoutIntervalForResource = 6000.0
 let httpMaximumConnectionsPerHost = 10
 
+let personalAccessToken = ProcessInfo.processInfo.environment["GH_API_TOKEN"]
+
+if personalAccessToken == nil {
+    print("Warning: Using anonymous authentication -- may run into rate limiting issues\n")
+}
+
 let config: URLSessionConfiguration = .default
 config.timeoutIntervalForRequest = timeoutIntervalForRequest
 config.timeoutIntervalForResource = timeoutIntervalForResource
@@ -48,6 +54,8 @@ enum ValidatorError: Error {
     case fileSystemError(Error)
     case badPackageDump(String?)
     case missingProducts
+    case rateLimitExceeded(Int)
+    case packageDoesNotExist(String)
     
     var localizedDescription: String {
         switch self {
@@ -65,6 +73,10 @@ enum ValidatorError: Error {
             return "Bad Package Dump -- \(output ?? "No Output")"
         case .missingProducts:
             return "Missing Products"
+        case .rateLimitExceeded(let limit):
+            return "Rate Limit of \(limit) Exceeded"
+        case .packageDoesNotExist(let url):
+            return "Package Does Not Exist: \(url)"
         }
     }
 }
@@ -81,9 +93,27 @@ func downloadSync(url: String, timeout: Int = 10) -> Result<Data, ValidatorError
     var payload: Data?
     var taskError: ValidatorError?
     
-    let task = session.dataTask(with: apiURL) { (data, _, error) in
+    var request = URLRequest(url: apiURL)
+    
+    if let pat = personalAccessToken {
+        request.addValue("token: \(pat)", forHTTPHeaderField: "Authorization")
+    }
+    
+    let task = session.dataTask(with: request) { (data, response, error) in
         
-        if let error = error {
+        let httpResponse = response as? HTTPURLResponse
+        
+        // TEMPORARY
+        print("Limit:", httpResponse?.value(forHTTPHeaderField: "X-RateLimit-Limit") ?? "No Limit")
+        // TEMPORARY
+        
+        if let limit = httpResponse?.value(forHTTPHeaderField: "X-RateLimit-Limit").flatMap(Int.init),
+           let remaining = httpResponse?.value(forHTTPHeaderField: "X-RateLimit-Remaining").flatMap(Int.init),
+           remaining == 0 {
+            taskError = .rateLimitExceeded(limit)
+        } else if httpResponse?.statusCode == 404 {
+            taskError = .packageDoesNotExist(apiURL.absoluteString)
+        } else if let error = error {
             taskError = .networkingError(error)
         }
         
@@ -138,15 +168,20 @@ func getPackageSwiftURL(url: URL) -> Result<URL, ValidatorError> {
     case .GitHub:
         let repositoryName = url.deletingPathExtension().lastPathComponent
         let userName = url.deletingLastPathComponent().lastPathComponent
-        let defaultBranch = (try? getDefaultBranch(userName: userName, repositoryName: repositoryName).get()) ?? "master"
-        var rawURLComponents = rawGitHubBaseURL
-        rawURLComponents.path = ["", userName, repositoryName, defaultBranch, "Package.swift"].joined(separator: "/")
         
-        guard let packageURL = rawURLComponents.url else {
-            return .failure(.invalidURL(url.absoluteString))
+        switch getDefaultBranch(userName: userName, repositoryName: repositoryName) {
+        case .success(let defaultBranch):
+            var rawURLComponents = rawGitHubBaseURL
+            rawURLComponents.path = ["", userName, repositoryName, defaultBranch, "Package.swift"].joined(separator: "/")
+            
+            guard let packageURL = rawURLComponents.url else {
+                return .failure(.invalidURL(url.absoluteString))
+            }
+            
+            return .success(packageURL)
+        case .failure(let failure):
+            return .failure(failure)
         }
-        
-        return .success(packageURL)
     }
     
 }

--- a/.validate.swift
+++ b/.validate.swift
@@ -96,9 +96,8 @@ func downloadSync(url: String, timeout: Int = 10) -> Result<Data, ValidatorError
     
     var request = URLRequest(url: apiURL)
     
-    if let pat = personalAccessToken, apiURL.host == SourceHost.GitHub.rawValue {
-        print("Adding PAT")
-        request.addValue("Bearer \(pat)", forHTTPHeaderField: "Authorization")
+    if let pat = personalAccessToken, apiURL.host == "api.github.com" {
+        request.addValue("Basic \(pat)", forHTTPHeaderField: "Authorization")
     }
     
     let task = session.dataTask(with: request) { (data, response, error) in

--- a/packages.json
+++ b/packages.json
@@ -1218,6 +1218,7 @@
   "https://github.com/kiliankoe/D20.git",
   "https://github.com/kiliankoe/DVB.git",
   "https://github.com/kiliankoe/gausskrueger.git",
+  "https://github.com/kiliankoe/GeoJSON.git",
   "https://github.com/kiliankoe/Karte.git",
   "https://github.com/kiliankoe/Nextbike.git",
   "https://github.com/kiliankoe/ParkKit.git",


### PR DESCRIPTION
Also fail if default branch can't be retrieved rather than defaulting.

Added GeoJSON as test data

Will remove temporary code once I'm confident that the token Dave has added is actually being picked up correctly by the API