### PR TITLE
Adds Flatbuffers

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1531,6 +1531,7 @@
   "https://github.com/mt-hodaka/CodableDefaults.git",
   "https://github.com/mtynior/ColorizeSwift.git",
   "https://github.com/mukeshydv/Inflect.git",
+  "https://github.com/mustiikhalil/flatbuffers.git",
   "https://github.com/muukii/Bulk.git",
   "https://github.com/muukii/JAYSON.git",
   "https://github.com/mw99/DataCompression.git",


### PR DESCRIPTION
The following PR adds Flatbuffers to `swiftpackageindex`, I've ran `swift ./validate.swift diff` 