### PR TITLE
Temporarily remove packages that depend on Swift 5.3.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2427,7 +2427,6 @@
   "https://github.com/twostraws/Sitrep.git",
   "https://github.com/twostraws/swiftgd.git",
   "https://github.com/twostraws/swiftslug.git",
-  "https://github.com/twostraws/VisualEffects.git",
   "https://github.com/typelift/abstract.git",
   "https://github.com/typelift/alchemy.git",
   "https://github.com/typelift/operadics.git",

--- a/packages.json
+++ b/packages.json
@@ -29,7 +29,6 @@
   "https://github.com/abdullahselek/SwiftyNotifications.git",
   "https://github.com/abdullahselek/TakeASelfie.git",
   "https://github.com/abeintopalo/appiconsetgen.git",
-  "https://github.com/achirkof/LoadableImage.git",
   "https://github.com/aciidb0mb3r/SwiftMQTT.git",
   "https://github.com/adam-fowler/aws-cognito-authentication.git",
   "https://github.com/adam-fowler/aws-signer.git",


### PR DESCRIPTION
Removing packages that rely on Swift 5.3 temporarily to fix the [issues with the smoke test](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/520).