### PR TITLE
Update GitHub Actions to use Swift 5.3 for validation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Select Xcode 11.4
-      run: sudo xcode-select -s /Applications/Xcode_11.4.app && xcodebuild -version
+    - name: Select Xcode 12
+      run: sudo xcode-select -s /Applications/Xcode_12.app && xcodebuild -version
     - name: Validate JSON
       run: swift validate.swift diff
   validate:
@@ -21,8 +21,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Select Xcode 11.4
-      run: sudo xcode-select -s /Applications/Xcode_11.4.app && xcodebuild -version
+    - name: Select Xcode 12
+      run: sudo xcode-select -s /Applications/Xcode_12.app && xcodebuild -version
     - name: Validate JSON
       run: swift .validate.swift
       env:


### PR DESCRIPTION
Merge **before** #465.
Merge **after** [SwiftPackageIndex-Server#517](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/517#event-3533771747) hits production.