### PR TITLE
Add Swift Type Adoption Reporter (STAR)

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2392,6 +2392,7 @@
   "https://github.com/thoughtbot/curry.git",
   "https://github.com/thoughtbot/modalpresentationview.git",
   "https://github.com/thoughtbot/runes.git",
+  "https://github.com/thumbtack/star.git",
   "https://github.com/tid-kijyun/Kanna.git",
   "https://github.com/tiferrei/UCLKit.git",
   "https://github.com/tikhop/TPInAppReceipt.git",


### PR DESCRIPTION
## Checklist

I have either:

* [x] Run `./validate.swift diff` before submitting this pull request.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
