### PR TITLE
Add NetworkImage package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1075,6 +1075,7 @@
   "https://github.com/gongzhang/swift-complex-number.git",
   "https://github.com/gonzalezreal/DefaultCodable.git",
   "https://github.com/gonzalezreal/Markup.git",
+  "https://github.com/gonzalezreal/NetworkImage.git",
   "https://github.com/gonzalezreal/Reusable.git",
   "https://github.com/gonzalezreal/SimpleNetworking.git",
   "https://github.com/gonzalezreal/UnifiedLogging.git",


### PR DESCRIPTION
## Checklist

I have either:

* [x] Run `./validate.swift diff` before submitting this pull request.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
