### PR TITLE
Adding Helper4Swift to Swift Package Index

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -492,6 +492,7 @@
   "https://github.com/crspybits/CredentialsDropbox.git",
   "https://github.com/crspybits/CredentialsMicrosoft.git",
   "https://github.com/crspybits/SwiftyAWSSNS.git",
+  "https://github.com/cs4alhaider/Helper4Swift.git",
   "https://github.com/cszatma/DiscreteMathematics.git",
   "https://github.com/cszatma/SwiftySweetness.git",
   "https://github.com/cuba/mongoorm.git",


### PR DESCRIPTION
## Checklist

I have:

* [x] Run `swift ./validate.swift`.
