### PR TITLE
Removed luoxiu/SuperCache

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1583,7 +1583,6 @@
   "https://github.com/luoxiu/Once.git",
   "https://github.com/luoxiu/rainbow.git",
   "https://github.com/luoxiu/Schedule.git",
-  "https://github.com/luoxiu/SuperCache.git",
   "https://github.com/lupuandrei/gfgoogledirection.git",
   "https://github.com/lvnkmn/InjectableLoggers.git",
   "https://github.com/lvnkmn/Zoomy.git",


### PR DESCRIPTION
Noticed as part of [this nightly run](https://github.com/SwiftPackageIndex/PackageList/runs/905888304?check_suite_focus=true) this little comment:

> 404: Not Found
> ERROR: Failed to obtain package information for /luoxiu/SuperCache.git
> packageDoesNotExist("https://raw.githubusercontent.com/luoxiu/SuperCache/master/Package.swift")

This is an error given when a repo exists, but the Package.swift (at the default branch) can't be found.

In this instance it looks like the package was, 16 hours ago, removed.

https://github.com/luoxiu/SuperCache

@daveverwer - do we want to capture this error as part of the nightly and automate the removal if we can't obtain the Package.swift or do you think that's a bad move? I can't think of all the implications.

I also noticed that URLs in the format like this: `git@github.com:microsoft/healthkit-to-fhir` are not being handled due to the crude way we extract details from the URL. Should be an easy patch but unlocks at least another 15 packages, currently.