### PR TITLE
Added LitFuseBasicPackage

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1698,6 +1698,7 @@
   "https://github.com/michaeleisel/ZippyJSON.git",
   "https://github.com/michaeleisel/ZippyJSONCFamily.git",
   "https://github.com/michaelhenry/RxRetroSwift.git",
+  "https://github.com/MichaelKucinski/LitFuseBasicPackage",
   "https://github.com/michaelnisi/fileproxy.git",
   "https://github.com/michaelnisi/skull.git",
   "https://github.com/micheltlutz/MLAudioPlayer.git",

--- a/packages.json
+++ b/packages.json
@@ -1698,7 +1698,7 @@
   "https://github.com/michaeleisel/ZippyJSON.git",
   "https://github.com/michaeleisel/ZippyJSONCFamily.git",
   "https://github.com/michaelhenry/RxRetroSwift.git",
-  "https://github.com/MichaelKucinski/LitFuseBasicPackage",
+  "https://github.com/MichaelKucinski/LitFuseBasicPackage.git",
   "https://github.com/michaelnisi/fileproxy.git",
   "https://github.com/michaelnisi/skull.git",
   "https://github.com/micheltlutz/MLAudioPlayer.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [LitFuseBasicPackage](https://github.com/MichaelKucinski/LitFuseBasicPackage)

## Checklist

I have either:

* [x ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
