### PR TITLE
adding SwiftJailbreakDetection

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2994,6 +2994,7 @@
   "https://github.com/watson-developer-cloud/swift-sdk.git",
   "https://github.com/way-to-code/git-macos.git",
   "https://github.com/wayfair/prelude.git",
+  "https://github.com/wearebeatcode/SwiftJailbreakDetection.git",
   "https://github.com/webfrogs/transformers.git",
   "https://github.com/Weebly/OrderedSet.git",
   "https://github.com/weichsel/ZIPFoundation.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwwiftJailbreakDetection](https://github.com/wearebeatcode/SwiftJailbreakDetection)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.
