### PR TITLE
Add "AppLogger"

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -274,6 +274,7 @@
   "https://github.com/Azure/azure-sdk-for-ios.git",
   "https://github.com/b3ll/Decomposed.git",
   "https://github.com/backslash-f/aescryptable.git",
+  "https://github.com/backslash-f/applogger.git",
   "https://github.com/backslash-f/operating-system.git",
   "https://github.com/backslash-f/simage.git",
   "https://github.com/backslash-f/Worker.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [AppLogger](https://github.com/backslash-f/applogger)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
