### PR TITLE
Do we need better error reporting when API calls fail?

### DIFF
--- a/validate.swift
+++ b/validate.swift
@@ -147,8 +147,11 @@ func downloadJSONSync<Payload: Decodable>(url: String, timeout: Int = 10) -> Res
         
     case .success(let data):
         do {
+            let payloadString = String(describing: String(data: data, encoding: .utf8))
+            print("payloadString: \(payloadString)")
             return .success(try decoder.decode(Payload.self, from: data))
         } catch {
+            print("error: \(error)")
             return .failure(.decoderError(error))
         }
     }


### PR DESCRIPTION
**NOT FOR MERGING**

So my local validation has been failing and I realised this morning it was because my local `GITHUB_TOKEN` had gone stale (I deleted it 😬) but the error message the script returns when this happens is... not ideal 😂

```
🚨 https://github.com/awesome/package.git: The data couldn’t be read because it is missing.
```

So I dug into where we might find a better error message, and this is what I found. Comments inline...