### PR TITLE
Add Test Utils Package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -8,6 +8,7 @@
   "https://github.com/1024jp/WFColorCode.git",
   "https://github.com/10clouds/ParticlePullToRefresh-iOS.git",
   "https://github.com/123flo321/pogoprotos-swift.git",
+  "https://github.com/1904labs/ios-test-utils.git",
   "https://github.com/1fr3dg/ResourcePackage.git",
   "https://github.com/1fr3dg/SimpleEncrypter.git",
   "https://github.com/1fr3dg/TextFormater.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Test Utils](https://github.com/1904labs/ios-test-utils)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
