### PR TITLE
Add xavierLowmiller/AppStorage

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3076,6 +3076,7 @@
   "https://github.com/WxWatch/DragonService.git",
   "https://github.com/wzxjiang/Sdifft.git",
   "https://github.com/X140Yu/pangu.Swift.git",
+  "https://github.com/xavierLowmiller/AppStorage.git",
   "https://github.com/xcessentials/apiclient.git",
   "https://github.com/xcessentials/optionalassign.git",
   "https://github.com/XCEssentials/Pipeline.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [AppStorage](https://github.com/xavierLowmiller/AppStorage)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.


For some reason, `swift ./validate.swift` outputs an error:
> 🚨 https://github.com/xavierLowmiller/AppStorage.git: Bad Package Dump -- /private/var/folders/nf/b_92fxhj4bz090d5_yd69r3r0000gn/T/25C6AB82-7D9B-4252-A95A-DA74E8833F55: error: package at '/private/var/folders/nf/b_92fxhj4bz090d5_yd69r3r0000gn/T/25C6AB82-7D9B-4252-A95A-DA74E8833F55' is using Swift tools version 5.3.0 but the installed version is 5.2.0

But it should be alright, because there is a `Package@swift-5.2.swift` for Xcode 11 compatibility. The validation script doesn't seem to catch that file, but running `swift package dump-package` locally works perfectly 👍.