### PR TITLE
Add AirKit and PolyKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1118,6 +1118,8 @@
   "https://github.com/hendriku/colorpicker.git",
   "https://github.com/HeroTransitions/Hero.git",
   "https://github.com/heshammegid/synchronousnetworking.git",
+  "https://github.com/hexagons/AirKit.git",
+  "https://github.com/hexagons/PolyKit.git",
   "https://github.com/hexagons/Trails.git",
   "https://github.com/hexaville/hexavilleauth.git",
   "https://github.com/hexedbits/AboutThisApp.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [AirKit](https://github.com/hexagons/AirKit)
* [PolyKit](https://github.com/hexagons/PolyKit)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.
