### PR TITLE
Add StatKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1319,6 +1319,7 @@
   "https://github.com/jflinter/Dwifft.git",
   "https://github.com/Jgump-max/MutableAttributedSting.git",
   "https://github.com/Jimmy-Lee/Networking.git",
+  "https://github.com/JimmyMAndersson/StatKit.git",
   "https://github.com/jinxiansen/guardian.git",
   "https://github.com/jjc1138/tiny-events.git",
   "https://github.com/jjjkkkjjj/Matft.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [StatKit](https://github.com/JimmyMAndersson/StatKit)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
