### PR TITLE
Add arweave-swift package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1613,6 +1613,7 @@
   "https://github.com/luizzak/minilexer.git",
   "https://github.com/lukaskubanek/OrderedDictionary.git",
   "https://github.com/lukasmoellerch/SwiftUIFormattedText.git",
+  "https://github.com/lukereichold/arweave-swift.git",
   "https://github.com/lukereichold/swift-multiaddr.git",
   "https://github.com/lukewar/Errands.git",
   "https://github.com/luoxiu/Chalk.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Arweave - Swift](https://github.com/lukereichold/arweave-swift)

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
