### PR TITLE
Add HashableByKeyPath and Persist

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1378,6 +1378,7 @@
   "https://github.com/josefdolezal/xcman.git",
   "https://github.com/JosephDuffy/HashableByKeyPath.git",
   "https://github.com/JosephDuffy/Partial.git",
+  "https://github.com/JosephDuffy/Persist.git",
   "https://github.com/JosephDuffy/SwiftChecksDangerPlugin.git",
   "https://github.com/josephroquedev/hive-engine.git",
   "https://github.com/josephroquedev/hive-mind.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [HashableByKeyPath](https://github.com/JosephDuffy/HashableByKeyPath)
* [Persist](https://github.com/JosephDuffy/Persist)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
