### PR TITLE
Remove freshplanapi

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1278,7 +1278,6 @@
   "https://github.com/iZettle/Flow.git",
   "https://github.com/iZettle/Lift.git",
   "https://github.com/j-channings/swift-package-manager-ios.git",
-  "https://github.com/j-nguyen/freshplanapi.git",
   "https://github.com/j-nguyen/investinginmeapi.git",
   "https://github.com/jacopomangiavacchi/swiftnormalization.git",
   "https://github.com/jacopomangiavacchi/thrift-swift-nio.git",


### PR DESCRIPTION
This also stalls the builders, see https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/664