### PR TITLE
add lightChart package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2160,6 +2160,7 @@
   "https://github.com/phimage/Prephirences.git",
   "https://github.com/phimage/ValueTransformerKit.git",
   "https://github.com/phimage/XcodeProjKit.git",
+  "https://github.com/pichukov/LightChart.git",
   "https://github.com/piemonte/Burst.git",
   "https://github.com/piemonte/Player.git",
   "https://github.com/piemonte/Poly.git",
@@ -3174,6 +3175,5 @@
   "https://github.com/zulip/swift-zulip-api.git",
   "https://github.com/zummenix/KeyboardNotificationsObserver.git",
   "https://github.com/zvonicek/ImageSlideshow.git",
-  "https://github.com/zweigraf/fakebundle.git",
-  "https://github.com/pichukov/LightChart.git"
+  "https://github.com/zweigraf/fakebundle.git"
 ]


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.
