### PR TITLE
Add CasperishTheme (a port of Ghost's Casper theme for Publish)

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2630,6 +2630,7 @@
   "https://github.com/sonsongithub/HTMLSpecialCharacters.git",
   "https://github.com/soracom/soracom-sdk-swift.git",
   "https://github.com/soucolline/ZLogger.git",
+  "https://github.com/sowenjub/CasperishTheme.git",
   "https://github.com/spacenation/swiftui-grid.git",
   "https://github.com/spectraldragon/templar.git",
   "https://github.com/speee/OreOre.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Casperish Theme](https://github.com/sowenjub/CasperishTheme)

## Checklist

I have:

* [X ] Run `swift ./validate.swift`.

Result was

```
+ https://github.com/sowenjub/CasperishTheme.git

1 package(s) passed
```

even though there is no tagged release: it depends on one package that is not tagged so it's not possible at the moment, but I definitely intend to tag it as soon as possible.