### PR TITLE
Add kaishin/gifu

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1411,6 +1411,7 @@
   "https://github.com/kaandedeoglu/KDCircularProgress.git",
   "https://github.com/kaandedeoglu/shark.git",
   "https://github.com/kaiede/rpilight.git",
+  "https://github.com/kaishin/Gifu.git",
   "https://github.com/kaishin/ImageScout.git",
   "https://github.com/kamcma/vapor-xfp-middleware.git",
   "https://github.com/kandelvijaya/algorithmchecker.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Gifu](https://github.com/kaishin/Gifu)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
