### PR TITLE
Add r-thomson/SwiftySass

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2285,6 +2285,7 @@
   "https://github.com/quver/SlidableImage.git",
   "https://github.com/quynhnguyen/slidingtabview.git",
   "https://github.com/r-dent/EliminationMenu.git",
+  "https://github.com/r-thomson/SwiftySass.git",
   "https://github.com/ra1028/DifferenceKit.git",
   "https://github.com/RACCommunity/FlexibleDiff.git",
   "https://github.com/raginmari/RAGTextField.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftySass](https://github.com/r-thomson/SwiftySass/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
