### PR TITLE
Add Telegraph

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -420,6 +420,7 @@
   "https://github.com/bryannorden/elo-rating-swift.git",
   "https://github.com/brycesteve/perfect-view2pdf.git",
   "https://github.com/BubiDevs/SwiftFlags.git",
+  "https://github.com/Building42/Telegraph.git",
   "https://github.com/bustoutsolutions/siesta.git",
   "https://github.com/buzzfeed/MockDuck.git",
   "https://github.com/bwetherfield/pitchspeller.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Telegraph](https://github.com/Building42/Telegraph)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
