### PR TITLE
added workingDog packages

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3095,6 +3095,8 @@
   "https://github.com/wolfmcnally/WolfStrings.git",
   "https://github.com/wolfmcnally/WolfWith.git",
   "https://github.com/Workable/swift-error-handler.git",
+  "https://github.com/workingDog/AgroApi.git",
+  "https://github.com/workingDog/OWOneCall.git",
   "https://github.com/woxtu/NSString-RemoveEmoji.git",
   "https://github.com/woxtu/RouteKit.git",
   "https://github.com/wtw-software/UTMConversion.git",
@@ -3197,3 +3199,4 @@
   "https://github.com/zvonicek/ImageSlideshow.git",
   "https://github.com/zweigraf/fakebundle.git"
 ]
+


### PR DESCRIPTION
The package(s) being submitted are:

* [AgroAPI](https://github.com/workingDog/AgroAPI)
* [OWOneCall](https://github.com/workingDog/OWOneCall)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
