### PR TITLE
add Action-Cable-Swift Client for Ruby on Rails ActionCable Socket Se…

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1898,6 +1898,7 @@
   "https://github.com/nerdsupremacist/GraphZahl.git",
   "https://github.com/nerdsupremacist/Ogma.git",
   "https://github.com/nerdsupremacist/Snap.git",
+  "https://github.com/nerzh/Action-Cable-Swift.git",
   "https://github.com/nevstad/blockchain-swift.git",
   "https://github.com/Nextdoor/corridor.git",
   "https://github.com/nextincrement/rsa-public-key-importer-exporter.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Action-Cable-Swift](https://github.com/nerzh/Action-Cable-Swift)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
