### PR TITLE
adding ShapeScript

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1916,6 +1916,7 @@
   "https://github.com/nicklockwood/Consumer.git",
   "https://github.com/nicklockwood/Euclid.git",
   "https://github.com/nicklockwood/Expression.git",
+  "https://github.com/nicklockwood/ShapeScript.git",
   "https://github.com/nicklockwood/SwiftFormat.git",
   "https://github.com/nicklockwood/VectorMath.git",
   "https://github.com/Nike-Inc/Elevate.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [ShapeScript](https://github.com/nicklockwood/ShapeScript)

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
