### PR TITLE
Adds SwiftUI-Introspect to packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2596,6 +2596,7 @@
   "https://github.com/sindresorhus/macos-wallpaper.git",
   "https://github.com/sindresorhus/Percentage.git",
   "https://github.com/sindresorhus/Preferences.git",
+  "https://github.com/siteline/SwiftUI-Introspect.git",
   "https://github.com/Sixt/Swack.git",
   "https://github.com/skagedal/appicon-generator.git",
   "https://github.com/skagedal/xcode-simulator-cert.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftUI-Introspect](https://github.com/siteline/SwiftUI-Introspect)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
