### PR TITLE
Adding secp256k1.swift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1037,6 +1037,7 @@
   "https://github.com/gg-a/gislib.git",
   "https://github.com/ggruen/swiftnetrc.git",
   "https://github.com/ghv/SVMPrefs.git",
+  "https://github.com/GigaBitcoin/secp256k1.swift.git",
   "https://github.com/giginet/Crossroad.git",
   "https://github.com/giginet/RxSpriteKit.git",
   "https://github.com/giginet/toybox.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [secp256k1.swift](https://github.com/GigaBitcoin/secp256k1.swift)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.
