### PR TITLE
SwiftUIPager addition

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -907,6 +907,7 @@
   "https://github.com/FelixHerrmann/FHConstraints.git",
   "https://github.com/FelixHerrmann/FHDiffableViewControllers.git",
   "https://github.com/FelixHerrmann/FHExtensions.git",
+  "https://github.com/fermoya/SwiftUIPager.git",
   "https://github.com/fernandodelrio/swiftcolorgenlibrary.git",
   "https://github.com/ferranabello/Viperit.git",
   "https://github.com/ferranpujolcamins/DotSwift.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftUIPager](https://github.com/fermoya/SwiftUIPager.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.
