### PR TITLE
Add nef to package index

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -403,6 +403,7 @@
   "https://github.com/bouke/srp.git",
   "https://github.com/bourvill/OpenWeatherKit.git",
   "https://github.com/bow-swift/bow.git",
+  "https://github.com/bow-swift/nef.git",
   "https://github.com/bppr/speck.git",
   "https://github.com/bradlarson/gpuimage2.git",
   "https://github.com/brainfinance/stackdriverlogging.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [nef](https://github.com/bow-swift/nef)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.
