### PR TITLE
Add sModel library

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -907,6 +907,7 @@
   "https://github.com/FabrizioBrancati/BFKit-Swift.git",
   "https://github.com/FabrizioBrancati/Queuer.git",
   "https://github.com/facebook/facebook-ios-sdk.git",
+  "https://github.com/FamilySearch/sModel.git",
   "https://github.com/fanpyi/UICollectionViewLeftAlignedLayout-Swift.git",
   "https://github.com/fassko/MeteoLVProvider.git",
   "https://github.com/fassko/TartuWeatherProvider.git",


### PR DESCRIPTION
The package(s) being submitted are:

* sModel (https://github.com/FamilySearch/sModel)

## Checklist

I have either:

* [ x ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
