### PR TITLE
Added SwiftQuiz and QSH

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1892,6 +1892,8 @@
   "https://github.com/rwbutler/Hyperconnectivity.git",
   "https://github.com/rwbutler/ipauploader.git",
   "https://github.com/rwbutler/LetterCase.git",
+  "https://github.com/rwbutler/QSH.git",
+  "https://github.com/rwbutler/swift-quiz.git",
   "https://github.com/rwbutler/TypographyKit.git",
   "https://github.com/rwbutler/typographykitpalette.git",
   "https://github.com/RxSwiftCommunity/Action.git",


### PR DESCRIPTION
A couple more to add! 🙂

The package(s) being submitted are:

* [SwiftQuiz](https://github.com/rwbutler/swift-quiz)
* [QSH](https://github.com/rwbutler/QSH)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.
