### PR TITLE
Add KeyboardKit and DynamicButtonStack

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -754,6 +754,8 @@
   "https://github.com/dokun1/vaux.git",
   "https://github.com/dominicegginton/spinner.git",
   "https://github.com/DominicHolmes/UIRotationEffect.git",
+  "https://github.com/douglashill/DynamicButtonStack.git",
+  "https://github.com/douglashill/KeyboardKit.git",
   "https://github.com/dougzilla32/CancelForPromiseKit.git",
   "https://github.com/dparnell/swift-parser-generator.git",
   "https://github.com/dral3x/stringslint.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [DynamicButtonStack](https://github.com/douglashill/DynamicButtonStack)
* [KeyboardKit](https://github.com/douglashill/KeyboardKit)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
