### PR TITLE
Add AppStoreReviewManager

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1679,6 +1679,7 @@
   "https://github.com/MaherKSantina/DSCore.git",
   "https://github.com/MakeAWishFoundation/SwiftyMocky.git",
   "https://github.com/makoni/couchdb-vapor.git",
+  "https://github.com/MAKoski/AppStoreReviewManager.git",
   "https://github.com/malcommac/FlowKit.git",
   "https://github.com/malcommac/Hydra.git",
   "https://github.com/malcommac/ImageSizeFetcher.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [AppStoreReviewManager](https://github.com/MAKoski/AppStoreReviewManager)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
