### PR TITLE
Add TwitterText and UnicodeURL

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2039,6 +2039,8 @@
   "https://github.com/num42/icon-resizer-swift.git",
   "https://github.com/nunomaia/cfoundationdb.git",
   "https://github.com/nvzqz/FileKit.git",
+  "https://github.com/nysander/twitter-text.git",
+  "https://github.com/nysander/UnicodeURL.git",
   "https://github.com/OakCityLabs/Endpoint.git",
   "https://github.com/OakCityLabs/RealmCoder.git",
   "https://github.com/OAuthSwift/OAuthSwift.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [TwitterText](https://github.com/nysander/twitter-text/)
* [UnicodeURL](https://github.com/nysander/UnicodeURL/)

## Checklist

I have either:

* [+] Run `swift ./validate.swift`.

Or, checked that:

* [+] The package repositories are publicly accessible.
* [+] The packages all contain a `Package.swift` file in the root folder.
* [+] The packages are written in Swift 4.0 or later.
* [+] The packages all contain at least one product (either library or executable).
* [+] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [+] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [+] The package URLs are all fully specified including `https` and the `.git` extension.
* [+] The packages all compile without errors.
