### PR TITLE
SwiftUICharts package added

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1758,6 +1758,7 @@
   "https://github.com/mcfedr/DNS.git",
   "https://github.com/mczachurski/swiftgger.git",
   "https://github.com/mdiep/Tentacle.git",
+  "https://github.com/mecid/SwiftUICharts.git",
   "https://github.com/mednoor/MNSwitchi.git",
   "https://github.com/meech-ward/focus.git",
   "https://github.com/meech-ward/observe.git",
@@ -3249,6 +3250,5 @@
   "https://github.com/zulip/swift-zulip-api.git",
   "https://github.com/zummenix/KeyboardNotificationsObserver.git",
   "https://github.com/zvonicek/ImageSlideshow.git",
-  "https://github.com/zweigraf/fakebundle.git",
-  "https://github.com/mecid/SwiftUICharts.git"
+  "https://github.com/zweigraf/fakebundle.git"
 ]

--- a/packages.json
+++ b/packages.json
@@ -3249,5 +3249,6 @@
   "https://github.com/zulip/swift-zulip-api.git",
   "https://github.com/zummenix/KeyboardNotificationsObserver.git",
   "https://github.com/zvonicek/ImageSlideshow.git",
-  "https://github.com/zweigraf/fakebundle.git"
+  "https://github.com/zweigraf/fakebundle.git",
+  "https://github.com/mecid/SwiftUICharts.git"
 ]


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftUICharts](https://github.com/mecid/SwiftUICharts)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.
