### PR TITLE
Added CryptomatorCloudAccess and CryptomatorCryptoLib

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -577,6 +577,8 @@
   "https://github.com/crspybits/CredentialsDropbox.git",
   "https://github.com/crspybits/CredentialsMicrosoft.git",
   "https://github.com/crspybits/SwiftyAWSSNS.git",
+  "https://github.com/cryptomator/cloud-access-swift.git",
+  "https://github.com/cryptomator/cryptolib-swift.git",
   "https://github.com/cs4alhaider/Helper4Swift.git",
   "https://github.com/cs4alhaider/NetworkKit.git",
   "https://github.com/cs4alhaider/ProfilePlaceholderView.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [CryptomatorCloudAccess](https://github.com/cryptomator/cloud-access-swift)
* [CryptomatorCryptoLib](https://github.com/cryptomator/cryptolib-swift)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
