### PR TITLE
Add LocalizedStringKit to package list

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1797,6 +1797,7 @@
   "https://github.com/microsoft/healthkit-on-fhir.git",
   "https://github.com/microsoft/healthkit-to-fhir.git",
   "https://github.com/microsoft/iomt-fhir-client.git",
+  "https://github.com/microsoft/localizedStringKit.git",
   "https://github.com/microsoft/plcrashreporter.git",
   "https://github.com/Mieraidihaimu/MMFoundation_swift.git",
   "https://github.com/mihaelamj/vaporcountries.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [LocalizedStringKit](https://github.com/microsoft/localizedStringKit.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
