### PR TITLE
Add Tracery to package list

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -333,6 +333,7 @@
   "https://github.com/benspratling4/swiftawssignaturev4.git",
   "https://github.com/benspratling4/swiftfoundationcompression.git",
   "https://github.com/benspratling4/SwiftPatterns.git",
+  "https://github.com/BenziAhamed/Tracery.git",
   "https://github.com/bergusman/evotor.git",
   "https://github.com/bermudadigitalstudio/cerberus.git",
   "https://github.com/bermudadigitalstudio/Log.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Tracery](https://github.com/BenziAhamed/Tracery)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.
