### PR TITLE
Added  trading-point/reactiveswift-composable-architecture

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2958,6 +2958,7 @@
   "https://github.com/toshi0383/rxsmartthrottle.git",
   "https://github.com/toshi0383/xcconfig-extractor.git",
   "https://github.com/totocaster/Typist.git",
+  "https://github.com/trading-point/reactiveswift-composable-architecture.git",
   "https://github.com/tribalworldwidelondon/CassowarySwift.git",
   "https://github.com/tribalworldwidelondon/PDFAuthor.git",
   "https://github.com/tristanhimmelman/ObjectMapper.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [reactiveswift-composable-architecture](https://github.com/trading-point/reactiveswift-composable-architecture)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.
