### PR TITLE
Add CDRCodable package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -736,6 +736,7 @@
   "https://github.com/Digipolitan/runtime-environment.git",
   "https://github.com/Digipolitan/session-kit.git",
   "https://github.com/dimakura/sspec.git",
+  "https://github.com/DimaRU/CDRCodable.git",
   "https://github.com/dimillian/swiftuiflux.git",
   "https://github.com/dimpiax/StyleDecorator.git",
   "https://github.com/DingSoung/Extension.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.
