### PR TITLE
Add Netswift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1883,6 +1883,7 @@
   "https://github.com/mrackwitz/Version.git",
   "https://github.com/mredig/SeaTouch.git",
   "https://github.com/mrlotu/swiftprometheus.git",
+  "https://github.com/MrSkwiggs/Netswift.git",
   "https://github.com/mrwerdo/geometry.git",
   "https://github.com/mshibanami/BiometryTypeBugWorkaround.git",
   "https://github.com/mt-hodaka/CodableDefaults.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Netswift](https://github.com/MrSkwiggs/Netswift)

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
