### PR TITLE
Nightly bearer token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,4 @@ jobs:
     - name: Validate JSON
       run: env DEVELOPER_DIR="/Applications/Xcode_12.0.app" swift validate.swift
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,16 +14,16 @@ jobs:
     - name: Run nightly script
       run: env DEVELOPER_DIR="/Applications/Xcode_12.0.app" swift nightly.swift
       env:
-        GH_API_TOKEN_BASE64: ${{ secrets.GH_API_TOKEN_BASE64 }}
+        GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
     - name: Run validation script
       run: env DEVELOPER_DIR="/Applications/Xcode_12.0.app" swift validate.swift
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
     - name: Create Pull Request
       id: cpr
       uses: peter-evans/create-pull-request@v3
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GH_API_TOKEN }}
         commit-message: Updated Packages
         title: '[Nightly] Updated Packages'
         body: |

--- a/nightly.swift
+++ b/nightly.swift
@@ -20,7 +20,7 @@ let rawGitHubBaseURL = URLComponents(string: "https://raw.githubusercontent.com"
 
 // We have a special Personal Access Token (PAT) which is used to increase our rate limit allowance up to 5,000 to enable
 // us to process every package.
-let patToken = ProcessInfo.processInfo.environment["GH_API_TOKEN_BASE64"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+let patToken = ProcessInfo.processInfo.environment["GH_API_TOKEN"]
 
 if patToken == nil {
     print("Warning: Using anonymous authentication -- you will quickly run into rate limiting issues\n")
@@ -105,7 +105,7 @@ func downloadSync(url: String, timeout: Int = 10) -> Result<Data, ValidatorError
     var request = URLRequest(url: apiURL)
     
     if let token = patToken, apiURL.host?.contains(SourceHost.GitHub.rawValue) == true {
-        request.addValue("Basic \(token)", forHTTPHeaderField: "Authorization")
+        request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
     }
     
     let task = session.dataTask(with: request) { (data, response, error) in

--- a/validate.swift
+++ b/validate.swift
@@ -17,10 +17,9 @@ let timeoutIntervalForResource = 6000.0
 let httpMaximumConnectionsPerHost = 10
 let processTimeout = 50.0
 
-// When run through GitHub Actions, we get access to a GitHub Token which is a Bearer Token.
-// This enables us to get an increased rate limit of 1000 so we're less likely to see issues.
-// Learn More: https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token
-let bearerToken = ProcessInfo.processInfo.environment["GITHUB_TOKEN"]
+// We have a special Personal Access Token (PAT) which is used to increase our rate limit allowance up to 5,000 to enable
+// us to process every package.
+let bearerToken = ProcessInfo.processInfo.environment["GH_API_TOKEN"]
 
 if bearerToken == nil {
     print("Warning: Using anonymous authentication -- may run into rate limiting issues\n")


### PR DESCRIPTION
Switches to Bearer token auth for nightly script and to `GH_API_TOKEN`, which is set as a secret for both scripts.

This should fix the following errors in the `nightly.swift` stage:

```
{"message":"API rate limit exceeded for 143.55.64.20. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://developer.github.com/v3/#rate-limiting"}
```

(This is why running this on prod would be dangerous.)