### PR TITLE
Temporarily remove swift-atomics

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -195,7 +195,6 @@
   "https://github.com/apple/example-package-playingcard.git",
   "https://github.com/apple/FHIRModels.git",
   "https://github.com/apple/swift-argument-parser.git",
-  "https://github.com/apple/swift-atomics.git",
   "https://github.com/apple/swift-corelibs-xctest.git",
   "https://github.com/apple/swift-crypto.git",
   "https://github.com/apple/swift-driver.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
