### PR TITLE
Stick with GITHUB_TOKEN for "Create PR" task

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
       id: cpr
       uses: peter-evans/create-pull-request@v3
       with:
-        token: ${{ secrets.GH_API_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Updated Packages
         title: '[Nightly] Updated Packages'
         body: |


### PR DESCRIPTION
Fixes https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/724 (again, 🤞)