### PR TITLE
Add xcrun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Validate JSON
-      run: env DEVELOPER_DIR="/Applications/Xcode_12.0.app" swift validate.swift
+      run: env DEVELOPER_DIR="/Applications/Xcode_12.0.app" xcrun swift validate.swift
       env:
         GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,11 +12,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Run nightly script
-      run: env DEVELOPER_DIR="/Applications/Xcode_12.0.app" swift nightly.swift
+      run: env DEVELOPER_DIR="/Applications/Xcode_12.0.app" xcrun swift nightly.swift
       env:
         GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
     - name: Run validation script
-      run: env DEVELOPER_DIR="/Applications/Xcode_12.0.app" swift validate.swift
+      run: env DEVELOPER_DIR="/Applications/Xcode_12.0.app" xcrun swift validate.swift
       env:
         GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
     - name: Create Pull Request


### PR DESCRIPTION
I'm grasping at straws here, I have no idea why PR validation is failing when run on Ceres. I've run the exact same command in the actual runner directory and and it passes.

If this doesn't fix it, we should probably keep the validation running on Github runners and only move the nightly to a dedicated one.