### PR TITLE
Switch ci.yml back to GH runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   validate:
-    runs-on: self-hosted
+    runs-on: macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Validate JSON
-      run: env DEVELOPER_DIR="/Applications/Xcode_12.0.app" xcrun swift validate.swift
+      run: env DEVELOPER_DIR="/Applications/Xcode_12.app" xcrun swift validate.swift
       env:
         GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}


### PR DESCRIPTION
I've tried running this from a dedicated runner on spi-dev and it's also failing with

```
Run env DEVELOPER_DIR="/Applications/Xcode_12.0.app" xcrun swift validate.swift
+ https://github.com/gonzalezreal/AdaptiveCardUI.git
🚨 https://github.com/gonzalezreal/AdaptiveCardUI.git: The data couldn’t be read because it is missing.

1 package(s) out of 1 failed
```

I have no idea why the dedicated runners are failing to run this job. I seems to work whenever I open PRs but there's nothing here that I can see that'd be tied to the user initiating the build.