### PR TITLE
Added ChatLayout and RouteComposer repositories.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -828,6 +828,8 @@
   "https://github.com/einstore/templator.git",
   "https://github.com/einstore/vaporerrorkit.git",
   "https://github.com/Einstore/WebErrorKit.git",
+  "https://github.com/ekazaev/ChatLayout.git",
+  "https://github.com/ekazaev/route-composer.git",
   "https://github.com/elegantchaos/Actions.git",
   "https://github.com/elegantchaos/ActionsKit.git",
   "https://github.com/elegantchaos/ApplicationExtensions.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [ChatLayout](https://github.com/ekazaev/ChatLayout) 
* [RouteComposer](https://github.com/ekazaev/route-composer)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.
