### PR TITLE
Switch validate.swift back to GITHUB_TOKEN, use xcrun for package dump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Validate JSON
-      run: env DEVELOPER_DIR="/Applications/Xcode_12.app" xcrun swift validate.swift
+      run: xcrun swift validate.swift
       env:
-        GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+        DEVELOPER_DIR: /Applications/Xcode_12.app
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/validate.swift
+++ b/validate.swift
@@ -19,7 +19,7 @@ let processTimeout = 50.0
 
 // We have a special Personal Access Token (PAT) which is used to increase our rate limit allowance up to 5,000 to enable
 // us to process every package.
-let bearerToken = ProcessInfo.processInfo.environment["GH_API_TOKEN"]
+let bearerToken = ProcessInfo.processInfo.environment["GITHUB_TOKEN"]
 
 if bearerToken == nil {
     print("Warning: Using anonymous authentication -- may run into rate limiting issues\n")
@@ -230,8 +230,8 @@ func downloadPackage(url: URL) -> Result<URL, ValidatorError> {
 
 func dumpPackageProcessAt(_ packageDirectoryURL: URL, outputTo pipe: Pipe, errorsTo errorPipe: Pipe) -> Process {
     let process = Process()
-    process.launchPath = "/usr/bin/swift"
-    process.arguments = ["package", "dump-package"]
+    process.launchPath = "/usr/bin/xcrun"
+    process.arguments = ["swift", "package", "dump-package"]
     process.currentDirectoryURL = packageDirectoryURL
     process.standardOutput = pipe
     process.standardError = errorPipe


### PR DESCRIPTION
The error message in recent failed validation jobs is `{"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}` and I noticed that while they fail on submission by others they seem to pass when submitted by us project members.

I'm wondering if it's due to the added secret vs the built-in `GITHUB_TOKEN` that's not a project secret.

Might be worth a try.

I've also changed `/usr/bin/swift` to use `xcrun` so it pick up the `DEVELOPER_DIR` variable we set.