### PR TITLE
Add apple/swift-algorithms

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -196,6 +196,7 @@
   "https://github.com/apple/example-package-fisheryates.git",
   "https://github.com/apple/example-package-playingcard.git",
   "https://github.com/apple/FHIRModels.git",
+  "https://github.com/apple/swift-algorithms.git"
   "https://github.com/apple/swift-argument-parser.git",
   "https://github.com/apple/swift-atomics.git",
   "https://github.com/apple/swift-corelibs-xctest.git",

--- a/packages.json
+++ b/packages.json
@@ -196,7 +196,7 @@
   "https://github.com/apple/example-package-fisheryates.git",
   "https://github.com/apple/example-package-playingcard.git",
   "https://github.com/apple/FHIRModels.git",
-  "https://github.com/apple/swift-algorithms.git"
+  "https://github.com/apple/swift-algorithms.git",
   "https://github.com/apple/swift-argument-parser.git",
   "https://github.com/apple/swift-atomics.git",
   "https://github.com/apple/swift-corelibs-xctest.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Apple - Swift Algorithms](https://github.com/apple/swift-algorithms) -  package of sequence and collection algorithms, along with their related types - [Blog Entry on swift.org](https://swift.org/blog/swift-algorithms)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
