### PR TITLE
Added SwiftSunburstDiagram

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1645,6 +1645,7 @@
   "https://github.com/ljcoder2015/LJTool.git",
   "https://github.com/lloydkeijzer/SwimpleAudio.git",
   "https://github.com/lloydkeijzer/SwimpleInjection.git",
+  "https://github.com/lludo/SwiftSunburstDiagram.git",
   "https://github.com/llvm-swift/clangswift.git",
   "https://github.com/llvm-swift/filecheck.git",
   "https://github.com/llvm-swift/lite.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftSunburstDiagram](https://github.com/lludo/SwiftSunburstDiagram)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.
