### PR TITLE
Add LNPopupController and LNPopupUI

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1622,6 +1622,8 @@
   "https://github.com/leixjin/WC-Swift.git",
   "https://github.com/lennet/flamegraph.git",
   "https://github.com/lennet/symbols.git",
+  "https://github.com/LeoNatan/LNPopupController.git",
+  "https://github.com/LeoNatan/LNPopupUI.git",
   "https://github.com/lexrus/MMDB-Swift.git",
   "https://github.com/liam923/MathKit.git",
   "https://github.com/ligr/appkit.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [LNPopupController](https://github.com/LeoNatan/LNPopupController)
* [LNPopupUI](https://github.com/LeoNatan/LNPopupUI)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
