### PR TITLE
Add SwiftCurrency to Package Index

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2186,6 +2186,7 @@
   "https://github.com/pducks32/Pailead.git",
   "https://github.com/pedantix/levellogger.git",
   "https://github.com/pedantix/TimedCache.git",
+  "https://github.com/Peek-Travel/swift-currency.git",
   "https://github.com/perfectaccelerators/applicationconfiguration.git",
   "https://github.com/perfectaccelerators/curly.git",
   "https://github.com/perfectaccelerators/perfectvalidation.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftCurrency](https://github.com/Peek-Travel/swift-currency)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [X] The package repositories are publicly accessible.
* [X] The packages all contain a `Package.swift` file in the root folder.
* [X] The packages are written in Swift 4.0 or later.
* [X] The packages all contain at least one product (either library or executable).
* [X] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [X] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [X] The package URLs are all fully specified including `https` and the `.git` extension.
* [X] The packages all compile without errors.
