### PR TITLE
New validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  new validation:
+  validate-new:
     runs-on: macos-latest
     continue-on-error: true
     steps:
@@ -19,7 +19,7 @@ jobs:
       env:
         DEVELOPER_DIR: /Applications/Xcode_12.app
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
+
   validate:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,17 @@ on:
     branches: [ main ]
 
 jobs:
+  new validation:
+    runs-on: macos-latest
+    continue-on-error: true
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Validate JSON (new)
+      run: xcrun swift new_validate.swift
+      env:
+        DEVELOPER_DIR: /Applications/Xcode_12.app
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   validate:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
+
   new validation:
     runs-on: macos-latest
     continue-on-error: true
@@ -14,10 +15,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Validate JSON (new)
-      run: xcrun swift new_validate.swift
+      run: xcrun swift .validate-new.swift
       env:
         DEVELOPER_DIR: /Applications/Xcode_12.app
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
   validate:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Validate JSON (new)
-      run: xcrun swift .validate-new.swift
+      run: |
+        xcrun swift .validate-new.swift
+        echo
+        echo packages.json diff:
+        git diff packages.json
+        echo
       env:
         DEVELOPER_DIR: /Applications/Xcode_12.app
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.validate-new.swift
+++ b/.validate-new.swift
@@ -81,6 +81,7 @@ class RedirectFollower: NSObject, URLSessionDataDelegate {
 
     func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
         lastURL = request.url ?? lastURL
+        // FIXME: port 404 and 429 handling from PackageList/Validator
         completionHandler(request)
     }
 }

--- a/new_validation.swift
+++ b/new_validation.swift
@@ -153,10 +153,22 @@ func getManifestURL(_ url: URL) throws -> URL {
     return URL(string: "https://raw.githubusercontent.com/\(owner)/\(repository)/\(defaultBranch)/Package.swift")!
 }
 
+func createTempDir() throws -> URL {
+    let fm = FileManager.default
+    let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try fm.createDirectory(at: tempDir, withIntermediateDirectories: false, attributes: nil)
+    return tempDir
+}
+
 func dumpPackage(url: URL) throws -> Data {
     let manifestURL = try getManifestURL(url)
-    print("manifest: \(manifestURL)")
-    // download package
+    let manifest = try fetch(manifestURL)
+    
+    let tempDir = try createTempDir()
+    let fileURL = tempDir.appendingPathComponent("Package.swift")
+    try manifest.write(to: fileURL)
+
+    print(fileURL.absoluteString)
     // swift dump package
     return Data()
 }

--- a/new_validation.swift
+++ b/new_validation.swift
@@ -1,0 +1,121 @@
+#!/usr/bin/env swift
+
+import Foundation
+
+
+// MARK: - Type declarations
+
+enum AppError: Error {
+    case syntaxError(String)
+
+    var localizedDescription: String {
+        switch self {
+            case .syntaxError(let msg):
+                return msg
+        }
+    }
+}
+
+enum RunMode {
+    case processURL(URL)
+    case processPackageList
+}
+
+
+// MARK: - Generic helpers
+
+
+// MARK: - Redirect handling
+
+class RedirectFollower: NSObject, URLSessionDataDelegate {
+    var lastURL: URL?
+    
+    func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
+        lastURL = request.url ?? lastURL
+        completionHandler(request)
+    }
+}
+
+extension URL {
+    func followingRedirects(timeout: TimeInterval = 30) -> URL? {
+        let semaphore = DispatchSemaphore(value: 0)
+        
+        let follower = RedirectFollower()
+        let session = URLSession(configuration: .default, delegate: follower, delegateQueue: nil)
+        
+        let task = session.dataTask(with: self) { (_, response, error) in
+            semaphore.signal()
+        }
+        
+        task.resume()
+        _ = semaphore.wait(timeout: .now() + timeout)
+        
+        return follower.lastURL
+    }
+}
+
+// MARK: - Script logic
+
+func parseArgs(_ args: [String]) throws -> RunMode {
+    guard args.count > 1 else { return .processPackageList }
+    let urlString = args[1]
+    guard
+        urlString.starts(with: "https://"),
+        let url = URL(string: urlString)
+        else { throw AppError.syntaxError("not a valid url: \(urlString)") }
+    return .processURL(url)
+}
+
+func processURL(_ url: URL) {
+    let resolvedURL = url.followingRedirects()
+    print(resolvedURL!.absoluteString)
+}
+
+func processPackageList() {
+    fatalError("not implemented")
+}
+
+func main(args: [String]) throws {
+    switch try parseArgs(args) {
+        case .processURL(let url):
+            processURL(url)
+        case .processPackageList:
+            processPackageList()
+    }
+    exit(EXIT_SUCCESS)
+}
+
+
+// MARK: - Script specific extensions
+
+extension String {
+    func removingGitExtension() -> String {
+        let suffix = ".git"
+        if lowercased().hasSuffix(suffix) {
+            return String(dropLast(suffix.count))
+        }
+        return self
+    }
+}
+
+extension URL {
+    func removingGitExtension() -> URL {
+        guard absoluteString.hasSuffix(".git") else { return self }
+        return URL(string: absoluteString.removingGitExtension())!
+    }
+}
+
+
+// MARK: - main
+
+do {
+    try main(args: CommandLine.arguments)
+} catch {
+    if let appError = error as? AppError {
+        print("ERROR: \(appError.localizedDescription)")
+    } else {
+        print(error)
+    }
+    exit(EXIT_FAILURE)
+}
+RunLoop.main.run()


### PR DESCRIPTION
Reworked validation. It's main feature is that it's shorter because it removes some of the things that are a holdout from when it was checking all urls in parallel. Making it serial allows us to remove a lot of the `Result` based error handling.

Before we even consider switching, I think it'd be good to let it run in parallel for a while to see how it goes. It's not like the current script is having any issues right now.