### PR TITLE
Add apple/swift-service-discovery

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -224,6 +224,7 @@
   "https://github.com/apple/swift-package-manager.git",
   "https://github.com/apple/swift-protobuf.git",
   "https://github.com/apple/swift-se0270-range-set.git",
+  "https://github.com/apple/swift-service-discovery.git",
   "https://github.com/apple/swift-statsd-client.git",
   "https://github.com/apple/swift-syntax.git",
   "https://github.com/apple/swift-system.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Apple - Swift Service Discovery](https://github.com/apple/swift-service-discovery) - https://swift.org/blog/swift-service-discovery/

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable).
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including `https` and the `.git` extension.
* [ ] The packages all compile without errors.
