### PR TITLE
StringIndex package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1360,6 +1360,7 @@
   "https://github.com/JohnEstropia/CoreStore.git",
   "https://github.com/johnfairh/RubyGateway.git",
   "https://github.com/johnfairh/TMLPersistentContainer.git",
+  "https://github.com/johnno1962/StringIndex.git",
   "https://github.com/johnno1962/SwiftRegex5.git",
   "https://github.com/johnno1962/SwiftTrace.git",
   "https://github.com/johnpatrickmorgan/Sparse.git",


### PR DESCRIPTION
Hi Dave,

The package(s) being submitted are:

* [StringIndex](https://github.com/johnno1962/StringIndex)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`. (does not run on Mojave)

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.