### PR TITLE
Added SwiftUIWindowBinder, removed old SwiftRootCAChallengeResolver

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1174,7 +1174,7 @@
   "https://github.com/happn-tech/SemiSingleton.git",
   "https://github.com/happn-tech/URLRequestOperation.git",
   "https://github.com/happycodelucky/SwiftBox.git",
-  "https://github.com/happycodelucky/SwiftRootCAChallengeResolver.git",
+  "https://github.com/happycodelucky/SwiftUIWindowBinder.git",
   "https://github.com/hartbit/Yaap.git",
   "https://github.com/healthtap/dangerxcodestaticanalyzer.git",
   "https://github.com/hebertialmeida/modelgen.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.
