### PR TITLE
Added SpotifyAPI

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1783,6 +1783,7 @@
   "https://github.com/peripheryapp/periphery.git",
   "https://github.com/persistx/schemata.git",
   "https://github.com/Peter-Schorn/RegularExpressions.git",
+  "https://github.com/Peter-Schorn/SpotifyAPI.git",
   "https://github.com/peterringset/JSONPatch.git",
   "https://github.com/petrpavlik/geoswift.git",
   "https://github.com/phatblat/WebView.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SpotifyAPI](https://github.com/Peter-Schorn/SpotifyAPI.git)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable).
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including `https` and the `.git` extension.
* [x] The packages all compile without errors.

I tried running `swift ./validate.swift`, but the script froze.