### PR TITLE
add ParseCareKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1990,6 +1990,7 @@
   "https://github.com/nerzh/Action-Cable-Swift.git",
   "https://github.com/nerzh/swift-extensions-pack.git",
   "https://github.com/nerzh/swift-regular-expression.git",
+  "https://github.com/netreconlab/ParseCareKit.git",
   "https://github.com/nevstad/blockchain-swift.git",
   "https://github.com/Nextdoor/corridor.git",
   "https://github.com/nextincrement/rsa-public-key-importer-exporter.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [ParseCareKit](https://github.com/netreconlab/ParseCareKit)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
