### PR TITLE
Add Swifter

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1766,6 +1766,7 @@
   "https://github.com/matrejek/SwiftEntitlements.git",
   "https://github.com/matsoftware/accept-language-parser.git",
   "https://github.com/matsune/MidiParser.git",
+  "https://github.com/mattdonnelly/Swifter.git",
   "https://github.com/MatteoBatti/Pager.git",
   "https://github.com/matter-labs/web3swift.git",
   "https://github.com/mattgallagher/cwlcatchexception.git",


### PR DESCRIPTION
A Twitter framework for iOS & OS X written in Swift

The package(s) being submitted are:

* [Swifter](https://github.com/mattdonnelly/Swifter)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
