### PR TITLE
Adds Braze/AppBoy SDK swift package repo

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -196,6 +196,7 @@
   "https://github.com/apparata/clikit.git",
   "https://github.com/apparata/markin.git",
   "https://github.com/apparata/rulekit.git",
+  "https://github.com/Appboy/appboy-ios-sdk.git",
   "https://github.com/appcompany/swift-sky.git",
   "https://github.com/appcraftstudio/buymeacoffee.git",
   "https://github.com/appcraftstudio/producthunt.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [App Boy/Braze](https://github.com/Appboy/appboy-ios-sdk)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
