### PR TITLE
Add SequenceBuilder package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -169,6 +169,7 @@
   "https://github.com/AndrewBarba/ed25519.git",
   "https://github.com/AndrewBarba/lisk-swift.git",
   "https://github.com/AndrewBennet/PersistedPropertyWrapper.git",
+  "https://github.com/andtie/SequenceBuilder.git",
   "https://github.com/andtie/YukonMatchedGeometry.git",
   "https://github.com/andybest/linenoise-swift.git",
   "https://github.com/andymedvedev/CTXTutorialEngine.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SequenceBuilder](https://github.com/andtie/SequenceBuilder/)

## Checklist

I have either:

* [x ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
