### PR TITLE
Adds ISO639.swift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2880,6 +2880,7 @@
   "https://github.com/SwiftORM/Storm.git",
   "https://github.com/SwiftPackageIndex/SemanticVersion.git",
   "https://github.com/SwiftPackageRepository/GameKitUI.swift.git",
+  "https://github.com/SwiftPackageRepository/ISO639.swift.git",
   "https://github.com/swiftrex/SwiftRex.git",
   "https://github.com/SwiftScream/URITemplate.git",
   "https://github.com/SwiftStudies/OysterKit.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [ISO639.swift](https://github.com/SwiftPackageRepository/ISO639.swift.git)

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [X] The package repositories are publicly accessible.
* [X] The packages all contain a `Package.swift` file in the root folder.
* [X] The packages are written in Swift 4.0 or later.
* [X] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [X] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [X] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [X] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [X] The packages all compile without errors.
* [X] The package list JSON file is sorted alphabetically.
