### PR TITLE
ConfettiSwiftUI added

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2697,6 +2697,7 @@
   "https://github.com/Shopify/FunctionalTableData.git",
   "https://github.com/shotastage/Fileable.swift.git",
   "https://github.com/siegesmund/SwiftDDP.git",
+  "https://github.com/simibac/ConfettiSwiftUI.git",
   "https://github.com/simonedelmann/crud-kit.git",
   "https://github.com/simonfairbairn/SwiftyMarkdown.git",
   "https://github.com/simonlee2/PlaceholderKit.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [ConfettiSwiftUI](https://github.com/simibac/ConfettiSwiftUI)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
