### PR TITLE
Add compnerd/cassowary

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -562,6 +562,7 @@
   "https://github.com/CombineHarvesters/FoundationCombine.git",
   "https://github.com/CombineHarvesters/HealthKitCombine.git",
   "https://github.com/commercetools/commercetools-ios-sdk.git",
+  "https://github.com/compnerd/cassowary.git",
   "https://github.com/composed-swift/composed.git",
   "https://github.com/composed-swift/composedui.git",
   "https://github.com/congnd/FMPhotoPicker.git",


### PR DESCRIPTION
Register compnerd/cassowary

The package(s) being submitted are:

* [cassowary](https://github.com/compnerd/cassowary/)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
