### PR TITLE
Add SwiftkubeModel and SwiftkubeClient

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2875,6 +2875,8 @@
   "https://github.com/swiftjava/java_lang.git",
   "https://github.com/swiftjava/java_swift.git",
   "https://github.com/swiftjava/java_util.git",
+  "https://github.com/swiftkube/client.git",
+  "https://github.com/swiftkube/model.git",
   "https://github.com/SwiftNIOExtras/swift-nio-irc.git",
   "https://github.com/SwiftNIOExtras/swift-nio-redis.git",
   "https://github.com/SwiftObjects/SwiftObjects.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftkubeModel](https://github.com/swiftkube/model.git)
* [SwiftkubeClient](https://github.com/swiftkube/client.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
