### PR TITLE
Add Contentstack

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -567,6 +567,7 @@
   "https://github.com/congnd/FMPhotoPicker.git",
   "https://github.com/contentful/contentful-persistence.swift.git",
   "https://github.com/contentful/contentful.swift.git",
+  "https://github.com/contentstack/contentstack-swift.git",
   "https://github.com/coodly/talktocloud.git",
   "https://github.com/CooperCorona/COpenBlas.git",
   "https://github.com/CooperCorona/CoronaErrors.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [ContentstackSwift](https://github.com/contentstack/contentstack-swift)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
