### PR TITLE
CodableJSON and CodableGeoJSON

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1167,6 +1167,8 @@
   "https://github.com/guillaumealgis/SimpleMDM-Swift.git",
   "https://github.com/guillermomuntaner/Burritos.git",
   "https://github.com/guseducampos/JustNetworking.git",
+  "https://github.com/guykogus/CodableGeoJSON.git",
+  "https://github.com/guykogus/CodableJSON.git",
   "https://github.com/gwynne/iniserialization.git",
   "https://github.com/h2glab/gitlab-provider.git",
   "https://github.com/hackiftekhar/IQKeyboardManager.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [CodableJSON](https://github.com/guykogus/CodableJSON.git)
* [CodableGeoJSON](https://github.com/guykogus/CodableGeoJSON.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
