### PR TITLE
Add Sherlouk/SPM

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2699,6 +2699,7 @@
   "https://github.com/shawnclovie/Spot.git",
   "https://github.com/shawnclovie/spotcache.git",
   "https://github.com/shawnclovie/spotpullrefresh.git",
+  "https://github.com/sherlouk/spm.git",
   "https://github.com/sherlouk/swiftprovisioningprofile.git",
   "https://github.com/shial4/SCountLabel.git",
   "https://github.com/shial4/SLazeCoreData.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SPM Executable](https://github.com/Sherlouk/spm)

Who doesn't love creating Swift Package dependency graphs?

![stars](https://raw.githubusercontent.com/Sherlouk/spm/main/Tests/GrapherTests/SampleProject/stars.svg)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
