### PR TITLE
Add Motion Package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -302,6 +302,7 @@
   "https://github.com/Azoy/SwordRPC.git",
   "https://github.com/Azure/azure-sdk-for-ios.git",
   "https://github.com/b3ll/Decomposed.git",
+  "https://github.com/b3ll/Motion.git",
   "https://github.com/backslash-f/aescryptable.git",
   "https://github.com/backslash-f/applogger.git",
   "https://github.com/backslash-f/gcoverseer.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Moation](https://github.com/b3ll/Motion)

## Checklist

I have either:

* [√ ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
