### PR TITLE
Add gonzalezreal/AttributedText package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1143,6 +1143,7 @@
   "https://github.com/gomfucius/CardStackView.git",
   "https://github.com/gonzalezreal/AdaptiveCardUI.git",
   "https://github.com/gonzalezreal/AnyValue.git",
+  "https://github.com/gonzalezreal/AttributedText.git",
   "https://github.com/gonzalezreal/DefaultCodable.git",
   "https://github.com/gonzalezreal/Markup.git",
   "https://github.com/gonzalezreal/NetworkImage.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [AttributedText](https://github.com/gonzalezreal/AttributedText)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
