### PR TITLE
Add michaelnisi/playback package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1861,6 +1861,7 @@
   "https://github.com/MichaelKucinski/EmitterFireworksAndExplosionsPackage.git",
   "https://github.com/MichaelKucinski/LitFuseBasicPackage.git",
   "https://github.com/michaelnisi/fileproxy.git",
+  "https://github.com/michaelnisi/playback.git",
   "https://github.com/michaelnisi/skull.git",
   "https://github.com/micheltlutz/MLAudioPlayer.git",
   "https://github.com/micheltlutz/MLLineChart.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Playback](https://github.com/michaelnisi/playback/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
