### PR TITLE
Adding Bugfender SDK

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -459,6 +459,7 @@
   "https://github.com/bryannorden/elo-rating-swift.git",
   "https://github.com/brycesteve/perfect-view2pdf.git",
   "https://github.com/BubiDevs/SwiftFlags.git",
+  "https://github.com/bugfender/BugfenderSDK-iOS.git",
   "https://github.com/Building42/HTTPParserC.git",
   "https://github.com/Building42/Telegraph.git",
   "https://github.com/bustoutsolutions/siesta.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Bugfender SDK](https://github.com/bugfender/BugfenderSDK-iOS/)

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
