### PR TITLE
Add OpenTelemetry for Swift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2193,6 +2193,7 @@
   "https://github.com/onmyway133/Smile.git",
   "https://github.com/onmyway133/Spek.git",
   "https://github.com/ootsamo/scheduleview.git",
+  "https://github.com/open-telemetry/opentelemetry-swift.git",
   "https://github.com/OpenCombine/OpenCombine.git",
   "https://github.com/OpenKitten/BSON.git",
   "https://github.com/OpenKitten/Cheetah.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-swift)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
