### PR TITLE
Added libRaw-swift package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3002,6 +3002,7 @@
   "https://github.com/tbaranes/SwiftyUtils.git",
   "https://github.com/tbaranes/VersionTrackerSwift.git",
   "https://github.com/tbxark/swift-telegram-bot-api.git",
+  "https://github.com/tclaus/libraw-swift.git",
   "https://github.com/tcldr/Entwine.git",
   "https://github.com/tdeleon/Relax.git",
   "https://github.com/techprimate/tppdf.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftLibRaw](https://github.com/tclaus/libraw-swift)

## Checklist

I have either:

* [ x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
