### PR TITLE
Add Yandex AppMetrica

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3329,6 +3329,7 @@
   "https://github.com/Yalantis/Segmentio.git",
   "https://github.com/yanamura/captain.git",
   "https://github.com/yanamura/Tempry.git",
+  "https://github.com/yandexmobile/metrica-sdk-ios.git",
   "https://github.com/yannickl/AwaitKit.git",
   "https://github.com/yannickl/DynamicButton.git",
   "https://github.com/yannickl/DynamicColor.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Yandex AppMetrica (aka Yandex Mobile Metrica)](https://github.com/yandexmobile/metrica-sdk-ios)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
