### PR TITLE
Add Laden and Shift packages

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3241,6 +3241,8 @@
   "https://github.com/vincentneo/CoreGPX.git",
   "https://github.com/vincode-io/VinContent.git",
   "https://github.com/vinhnx/DictionaryNestedSubscript.git",
+  "https://github.com/vinhnx/Laden.git",
+  "https://github.com/vinhnx/Shift.git",
   "https://github.com/vinhnx/spawn.git",
   "https://github.com/vinhnx/vintage.git",
   "https://github.com/viniciusaro/SwiftMarkdown.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Laden](https://github.com/vinhnx/Laden.git)
* [Shift](https://github.com/vinhnx/Shift.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
