### PR TITLE
Added two of my packages

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -265,6 +265,8 @@
   "https://github.com/armadsen/ORSSerialPort.git",
   "https://github.com/arn00s/caralho.git",
   "https://github.com/arn00s/cariocamenu.git",
+  "https://github.com/ArnavMotwani/CircularProgressSwiftUI.git",
+  "https://github.com/ArnavMotwani/UnsplashSwiftUI.git",
   "https://github.com/arnecs/mqttkit.git",
   "https://github.com/artemkalinovsky/Legatus.git",
   "https://github.com/artemnovichkov/carting.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [UnsplashSwiftUI](https://github.com/ArnavMotwani/UnsplashSwiftUI)
* [CircularProgressSwiftUI](https://github.com/ArnavMotwani/CircularProgressSwiftUI)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
