### PR TITLE
Add RBBJSON

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2567,6 +2567,7 @@
   "https://github.com/RNCryptor/RNCryptor.git",
   "https://github.com/rnine/Checksum.git",
   "https://github.com/robb/Cartography.git",
+  "https://github.com/robb/RBBJSON.git",
   "https://github.com/robbiehanson/CocoaAsyncSocket.git",
   "https://github.com/roberthein/Ease.git",
   "https://github.com/roberthein/Observable.git",


### PR DESCRIPTION
Looks like we need to wait for GH to resolve the 11.0 runner availability.

While tests run normally with `macos-latest` (== `macos-10.15`), this fails with multiple packages being added. That's why we went for 11.0 to begin with. I've tried 11.1 (not available yet) and Xcode 12.3 also doesn't fix the issue so it looks like we're stuck here for now.