### PR TITLE
Add CoreTempMonitorSwift package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -563,6 +563,7 @@
   "https://github.com/codeeagle/rocketboot.git",
   "https://github.com/codeinversion/sensors-swift-trainers.git",
   "https://github.com/codeinversion/sensors-swift.git",
+  "https://github.com/CodeNationDev/CoreTempMonitorSwift.git",
   "https://github.com/CodeNationDev/SimplyLogger.git",
   "https://github.com/CodeNationDev/UIMagicDropDown.git",
   "https://github.com/codeOfRobin/CloudKitFeatureFlags.git",


### PR DESCRIPTION
The package(s) being submitted are:

* CoreTempMonitorSwift

## Checklist

I have either:

* [x ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
