### PR TITLE
Runs on linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,4 @@ jobs:
     - name: Validate JSON
       run: docker run --rm -v "$PWD:/host" -w /host swift:5.3 swift validate.swift
       env:
-        DEVELOPER_DIR: /Applications/Xcode_12.2.app
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   validate:
-    runs-on: macos-11.0
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Validate JSON
-      run: xcrun swift validate.swift
+      run: docker run --rm -v "$PWD:/host" -w /host swift:5.3 swift validate.swift
       env:
         DEVELOPER_DIR: /Applications/Xcode_12.2.app
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages.json
+++ b/packages.json
@@ -998,8 +998,6 @@
   "https://github.com/finestructure/Gala.git",
   "https://github.com/finestructure/Parser.git",
   "https://github.com/finestructure/Rester.git",
-  "https://github.com/finestructure/swift-test-pkg-1.git",
-  "https://github.com/finestructure/swift-test-pkg-2.git",
   "https://github.com/finestructure/ValueCodable.git",
   "https://github.com/firebase/abseil-cpp-SwiftPM.git",
   "https://github.com/firebase/boringssl-SwiftPM.git",

--- a/packages.json
+++ b/packages.json
@@ -998,6 +998,8 @@
   "https://github.com/finestructure/Gala.git",
   "https://github.com/finestructure/Parser.git",
   "https://github.com/finestructure/Rester.git",
+  "https://github.com/finestructure/swift-test-pkg-1.git",
+  "https://github.com/finestructure/swift-test-pkg-2.git",
   "https://github.com/finestructure/ValueCodable.git",
   "https://github.com/firebase/abseil-cpp-SwiftPM.git",
   "https://github.com/firebase/boringssl-SwiftPM.git",

--- a/validate.swift
+++ b/validate.swift
@@ -244,8 +244,8 @@ func createTempDir() throws -> URL {
 
 func createDumpPackageProcess(at path: URL, standardOutput: Pipe, standardError: Pipe) -> Process {
     let process = Process()
-    process.launchPath = "/usr/bin/xcrun"
-    process.arguments = ["swift", "package", "dump-package"]
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/swift")
+    process.arguments = ["package", "dump-package"]
     process.currentDirectoryURL = path
     process.standardOutput = standardOutput
     process.standardError = standardError
@@ -268,7 +268,7 @@ func runDumpPackage(at path: URL, timeout: TimeInterval = 20) throws -> Data {
     DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
         if process.isRunning { process.terminate() }
     }
-    process.launch()
+    try process.run()
     process.waitUntilExit()
     
     switch process.terminationStatus {

--- a/validate.swift
+++ b/validate.swift
@@ -1,6 +1,9 @@
 #!/usr/bin/env swift
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 // MARK: - Constants
 


### PR DESCRIPTION
We don't actually need to install Swift if we run it via docker. Passes for two dependencies, so we don't run into the issue we're having with macOS 10.15: https://github.com/SwiftPackageIndex/PackageList/runs/1649890218?check_suite_focus=true

Will remove those fake packages and clean up for merge.

Nightly will remain on macOS for now but we could probably move that as well.

Merge after #851 