### PR TITLE
Adding SwiftZip

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2977,6 +2977,7 @@
   "https://github.com/SwiftyLinkerKit/SwiftyLinkerKit.git",
   "https://github.com/SwiftyLinkerKit/SwiftyTM1637.git",
   "https://github.com/SwiftyTesseract/libtesseract.git",
+  "https://github.com/SwiftZip/SwiftZip.git",
   "https://github.com/SwingDev/RxSwiftAutoRetry.git",
   "https://github.com/Swinject/Swinject.git",
   "https://github.com/Swinject/SwinjectAutoregistration.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftZip](https://github.com/SwiftZip/SwiftZip/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
