### PR TITLE
Add SenseHat package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3180,6 +3180,7 @@
   "https://github.com/valdirunars/bigintcompress.git",
   "https://github.com/valdirunars/bioswift.git",
   "https://github.com/valeriomazzeo/docker-client-swift.git",
+  "https://github.com/valeriyvan/RaspberryPiSenseHat.git",
   "https://github.com/vapor-community/async.git",
   "https://github.com/vapor-community/checkpoint.git",
   "https://github.com/vapor-community/copenssl.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SenseHat](https://github.com/valeriyvan/RaspberryPiSenseHat)

## Checklist

I have either:

* [x ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
