### PR TITLE
Add FractionFormatter to package list

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -712,6 +712,7 @@
   "https://github.com/davidskrundz/math.git",
   "https://github.com/davidskrundz/regex.git",
   "https://github.com/davidstump/SwiftPhoenixClient.git",
+  "https://github.com/davidwkeith/FractionFormatter.git",
   "https://github.com/dbsystel/DBNetworkStack.git",
   "https://github.com/dchakarov/TrainInformationService.git",
   "https://github.com/dcorvasce/decamelize.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [FractionFormatter](https://github.com/davidwkeith/FractionFormatter/)

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
