### PR TITLE
Add GEOSwiftMapKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1119,6 +1119,7 @@
   "https://github.com/genius/future.git",
   "https://github.com/GEOSwift/geos.git",
   "https://github.com/GEOSwift/GEOSwift.git",
+  "https://github.com/GEOSwift/GEOSwiftMapKit.git",
   "https://github.com/Gerzer/JSONParser.git",
   "https://github.com/getGuaka/Args.git",
   "https://github.com/getGuaka/Colorizer.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [GEOSwiftMapKit](https://github.com/GEOSwift/GEOSwiftMapKit)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
