### PR TITLE
Add UIView-Shimmer package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2188,6 +2188,7 @@
   "https://github.com/oliveroneill/WebBrowser.git",
   "https://github.com/ollieatkinson/Predicate.git",
   "https://github.com/omaralbeik/UserDefaultsStore.git",
+  "https://github.com/omerfarukozturk/UIView-Shimmer.git",
   "https://github.com/omichde/AttributedText.git",
   "https://github.com/omochi/bitcodeformat.git",
   "https://github.com/omochi/DebugReflect.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
