### PR TITLE
Add wren-swift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -145,6 +145,7 @@
   "https://github.com/AlwaysRightInstitute/SwiftyExpat.git",
   "https://github.com/AlwaysRightInstitute/SwiftyWasmer.git",
   "https://github.com/AlwaysRightInstitute/WebPackMiniS.git",
+  "https://github.com/AlwaysRightInstitute/wren-swift.git",
   "https://github.com/amadeu01/atlas.git",
   "https://github.com/amarantedaniel/JanusSwift.git",
   "https://github.com/amatino-code/amatino-swift.git",


### PR DESCRIPTION
Wren is an embeddable scripting language like Lua, but more
Smalltalky and w/ less weirdness.
This is Wren packages as an SPM package, plus a Swift API
wrapper to invoke it.

The package(s) being submitted are:

* [wren-swift](https://github.com/AlwaysRightInstitute/wren-swift/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
