### PR TITLE
Added mattt/CommonMarkAttributedString.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1845,6 +1845,7 @@
   "https://github.com/mattpolzin/OpenAPIKit.git",
   "https://github.com/mattpolzin/Poly.git",
   "https://github.com/mattpolzin/swift-test-codecov.git",
+  "https://github.com/mattt/CommonMarkAttributedString.git",
   "https://github.com/mattt/euler.git",
   "https://github.com/maustinstar/swiftui-drawer.git",
   "https://github.com/mavisbroadcast/amf.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [CommonMarkAttributedString](https://github.com/mattt/CommonMarkAttributedString.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Supercedes #878 without the GitLab URL.