### PR TITLE
Add PhotoEditorSDK and VideoEditorSDK

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1325,6 +1325,8 @@
   "https://github.com/imaginary-cloud/CameraManager.git",
   "https://github.com/imbue11235/EventHub.git",
   "https://github.com/imcd23/ibuild.git",
+  "https://github.com/imgly/pesdk-ios-build.git",
+  "https://github.com/imgly/vesdk-ios-build.git",
   "https://github.com/inamiy/FunOptics.git",
   "https://github.com/inamiy/RxAutomaton.git",
   "https://github.com/inamiy/rxproperty.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [PhotoEditorSDK](https://github.com/imgly/pesdk-ios-build)
* [VideoEditorSDK](https://github.com/imgly/vesdk-ios-build)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
