### PR TITLE
Add ScrollViewController, SwiftEndpoint and swiftui-app-icon-creator

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -679,6 +679,7 @@
   "https://github.com/Darkngs/DECardNumberFormatter.git",
   "https://github.com/Darkngs/DEPhoneNumberFormatter.git",
   "https://github.com/DarkySwift/KangarooStore.git",
+  "https://github.com/darrarski/ScrollViewController.git",
   "https://github.com/DarthStrom/Moxie.git",
   "https://github.com/dasautoooo/Parma.git",
   "https://github.com/dastrobu/argtree.git",

--- a/packages.json
+++ b/packages.json
@@ -681,6 +681,7 @@
   "https://github.com/DarkySwift/KangarooStore.git",
   "https://github.com/darrarski/ScrollViewController.git",
   "https://github.com/darrarski/SwiftEndpoint.git",
+  "https://github.com/darrarski/swiftui-app-icon-creator.git",
   "https://github.com/DarthStrom/Moxie.git",
   "https://github.com/dasautoooo/Parma.git",
   "https://github.com/dastrobu/argtree.git",

--- a/packages.json
+++ b/packages.json
@@ -680,6 +680,7 @@
   "https://github.com/Darkngs/DEPhoneNumberFormatter.git",
   "https://github.com/DarkySwift/KangarooStore.git",
   "https://github.com/darrarski/ScrollViewController.git",
+  "https://github.com/darrarski/SwiftEndpoint.git",
   "https://github.com/DarthStrom/Moxie.git",
   "https://github.com/dasautoooo/Parma.git",
   "https://github.com/dastrobu/argtree.git",


### PR DESCRIPTION
The packages being submitted are:

* [ScrollViewController](https://github.com/darrarski/ScrollViewController)
* [SwiftEndpoint](https://github.com/darrarski/SwiftEndpoint)
* [swiftui-app-icon-creator](https://github.com/darrarski/swiftui-app-icon-creator)

## Checklist

I have:

* [x] Run `swift ./validate.swift`.

and checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
