### PR TITLE
Added fastlane/fastlane.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -988,6 +988,7 @@
   "https://github.com/fanpyi/UICollectionViewLeftAlignedLayout-Swift.git",
   "https://github.com/fassko/MeteoLVProvider.git",
   "https://github.com/fassko/TartuWeatherProvider.git",
+  "https://github.com/fastlane/fastlane.git",
   "https://github.com/fastred/DeallocationChecker.git",
   "https://github.com/fauna/faunadb-swift.git",
   "https://github.com/favret/poutoupush.git",


### PR DESCRIPTION
How on earth was this not in the index? 😱

The package(s) being submitted are:

* [fastlane](https://github.com/fastlane/fastlane.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.
