### PR TITLE
Remove 404 repo

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1829,7 +1829,6 @@
   "https://github.com/marekpridal/LogKit.git",
   "https://github.com/marijanp/kvvliveapi.git",
   "https://github.com/marinofelipe/CurrencyText.git",
-  "https://github.com/marioiannotta/atomicswift.git",
   "https://github.com/marksands/BetterCodable.git",
   "https://github.com/marlimox/AloeStackView.git",
   "https://github.com/marmelroy/Localize-Swift.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
