### PR TITLE
Remove stuartcarnie/SwiftSPIRV-Cross.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2909,7 +2909,6 @@
   "https://github.com/stiivi/dotwriter.git",
   "https://github.com/stiivi/parsercombinator.git",
   "https://github.com/stoneburner/ShowSomeProgress.git",
-  "https://github.com/stuartcarnie/SwiftSPIRV-Cross.git",
   "https://github.com/studio-rookery/timekit.git",
   "https://github.com/subito-it/bariloche.git",
   "https://github.com/sunlubo/swiftffmpeg.git",


### PR DESCRIPTION
No longer has a Package.swift file.
