### PR TITLE
Add RomanNumeralKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1707,6 +1707,7 @@
   "https://github.com/kylef/spectre.git",
   "https://github.com/kylef/URITemplate.swift.git",
   "https://github.com/kylehickinson/swiftui-webview.git",
+  "https://github.com/kylehughes/RomanNumeralKit.git",
   "https://github.com/kyleishie/stripekit.git",
   "https://github.com/kyouko-taiga/argparse.git",
   "https://github.com/kyouko-taiga/logickit.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [RomanNumeralKit](https://github.com/kylehughes/RomanNumeralKit)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
