### PR TITLE
Add Amplitude

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -162,6 +162,7 @@
   "https://github.com/amosavian/ExtendedAttributes.git",
   "https://github.com/amosavian/FileProvider.git",
   "https://github.com/amosavian/LocaleManager.git",
+  "https://github.com/amplitude/Amplitude-iOS.git",
   "https://github.com/amraboelela/CLevelDB.git",
   "https://github.com/amraboelela/swiftleveldb.git",
   "https://github.com/amzn/service-model-swift-code-generate.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Amplitude-iOS](https://github.com/amplitude/Amplitude-iOS)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
