### PR TITLE
Added the Swift-String-Obfuscator and SwiftUI_ContactPicker packages.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2502,6 +2502,8 @@
   "https://github.com/pvzig/SKServer.git",
   "https://github.com/pvzig/SKWebAPI.git",
   "https://github.com/pvzig/SlackKit.git",
+  "https://github.com/pykaso/Swift-String-Obfuscator.git",
+  "https://github.com/pykaso/SwiftUI_ContactPicker.git",
   "https://github.com/q-mobile/qgrid.git",
   "https://github.com/q231950/commands.git",
   "https://github.com/qata/recombine.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Swift-String-Obfuscator](https://github.com/pykaso/Swift-String-Obfuscator)
* [SwiftUI_ContactPicker](https://github.com/pykaso/SwiftUI_ContactPicker)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
