### PR TITLE
Add SwiftyBibtex

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1886,6 +1886,7 @@
   "https://github.com/mavisbroadcast/amf.git",
   "https://github.com/MaxDesiatov/typology.git",
   "https://github.com/MaxDesiatov/XMLCoder.git",
+  "https://github.com/MaxHaertwig/SwiftyBibtex.git",
   "https://github.com/maximbilan/SwiftGoogleTranslate.git",
   "https://github.com/maximbilan/SwiftOxfordAPI.git",
   "https://github.com/maxsokolov/TableKit.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftyBibtex](https://github.com/MaxHaertwig/SwiftyBibtex)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
