### PR TITLE
Add Google Maps Swift Package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3447,6 +3447,7 @@
   "https://github.com/yaslab/CSV.swift.git",
   "https://github.com/yasumoto/digicertswift.git",
   "https://github.com/yasumoto/fluent-dynamodb.git",
+  "https://github.com/YAtechnologies/GoogleMaps-SP.git",
   "https://github.com/yasumoto/menkyo.git",
   "https://github.com/yenom/BitcoinKit.git",
   "https://github.com/yeokm1/swiftserial.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Google Maps Swift Package](https://github.com/YAtechnologies/GoogleMaps-SP/)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
