### PR TITLE
Add String+Japanese

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -462,6 +462,7 @@
   "https://github.com/bradlarson/gpuimage2.git",
   "https://github.com/brainfinance/stackdriverlogging.git",
   "https://github.com/brettfazio/CameraView.git",
+  "https://github.com/brevansio/String-Japanese.git",
   "https://github.com/bricklife/boostblekit.git",
   "https://github.com/bricklife/JSONRPCKit.git",
   "https://github.com/brightdigit/AssetLib.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [String+Japanese](https://github.com/brevansio/String-Japanese)

String+Japanese provides simple tools to convert between Latin, Hiragana, Katakana, and (Japanese) Kanji characters.

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
