### PR TITLE
Add BroadcastWriter to package list

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2692,6 +2692,7 @@
   "https://github.com/rockfordwei/perfect-ini.git",
   "https://github.com/rockfordwei/perfect-pcre2.git",
   "https://github.com/rockfordwei/perfect-squishy.git",
+  "https://github.com/romiroma/BroadcastWriter.git",
   "https://github.com/ronanrodrigo/Frisbee.git",
   "https://github.com/royit/RLayoutKit.git",
   "https://github.com/roznet/FitFileParser.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [ +] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
