### PR TITLE
Add CombineRx package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1395,6 +1395,7 @@
   "https://github.com/iZettle/Flow.git",
   "https://github.com/iZettle/Lift.git",
   "https://github.com/j-channings/swift-package-manager-ios.git",
+  "https://github.com/Jackstone92/CombineRx.git",
   "https://github.com/jacopomangiavacchi/swiftnormalization.git",
   "https://github.com/jacopomangiavacchi/thrift-swift-nio.git",
   "https://github.com/jadengeller/axiomatic.git",


### PR DESCRIPTION
The package being submitted is:

* [CombineRx](https://github.com/Jackstone92/CombineRx)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
