### PR TITLE
Add soto-s3-file-transfer

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2951,6 +2951,7 @@
   "https://github.com/soracom/soracom-sdk-swift.git",
   "https://github.com/soto-project/soto-cognito-authentication-kit.git",
   "https://github.com/soto-project/soto-core.git",
+  "https://github.com/soto-project/soto-s3-file-transfer.git",
   "https://github.com/soto-project/soto.git",
   "https://github.com/soucolline/ZLogger.git",
   "https://github.com/sowenjub/CasperishTheme.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Soto S3 File Transfer](https://github.com/soto-project/soto-s3-file-transfer)

## Checklist

I have either:

* [x ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
