### PR TITLE
Add Swift Package for supporting Sign in with Apple on Vapor

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2076,6 +2076,7 @@
   "https://github.com/Moya/Moya.git",
   "https://github.com/mpangburn/FunctionKit.git",
   "https://github.com/mpapp/mptimer.git",
+  "https://github.com/mpdifran/vapor-sign-in-with-apple.git",
   "https://github.com/mrackwitz/Version.git",
   "https://github.com/mredig/SeaTouch.git",
   "https://github.com/mrlotu/swiftprometheus.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SignInWithApple](https://github.com/mpdifran/vapor-sign-in-with-apple)

## Checklist

I have:

* [x] Run `swift ./validate.swift`.
