### PR TITLE
Add PostHog Package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2512,6 +2512,7 @@
   "https://github.com/Ponyboy47/TaskKit.git",
   "https://github.com/ponyboy47/Termios.git",
   "https://github.com/ponyboy47/TranscodeVideo.git",
+  "https://github.com/PostHog/posthog-ios.git",
   "https://github.com/postmates/PMJSON.git",
   "https://github.com/poulpix/PXGoogleDirections.git",
   "https://github.com/powerje/telnetkit.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [PostHog iOS](https://github.com/PostHog/posthog-ios)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
