### PR TITLE
Adding ASEnterprise

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3171,6 +3171,7 @@
   "https://github.com/ThasianX/ElegantCalendar.git",
   "https://github.com/ThasianX/ElegantColorPalette.git",
   "https://github.com/ThasianX/ElegantPages.git",
+  "https://github.com/theappstudiollc/ASEnterprise.git",
   "https://github.com/theappstudiollc/CoreResolve.git",
   "https://github.com/thebluepotato/AlamoFuzi.git",
   "https://github.com/TheCoderMerlin/Curses.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [ASEnterprise](https://github.com/theappstudiollc/ASEnterprise)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
