### PR TITLE
adding Options

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -474,6 +474,7 @@
   "https://github.com/brightdigit/Base32Crockford.git",
   "https://github.com/brightdigit/GampKit.git",
   "https://github.com/brightdigit/MistKit.git",
+  "https://github.com/brightdigit/Options.git",
   "https://github.com/brightdigit/SwiftVer.git",
   "https://github.com/Brightify/ReactantUI.git",
   "https://github.com/broadwaylamb/gottagofast.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Options](https://github.com/brightdigit/Options.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
