### PR TITLE
Added mflknr/SwiftVersionCompare

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1977,6 +1977,7 @@
   "https://github.com/Meniny/Zipper.git",
   "https://github.com/mentalfaculty/LLVS.git",
   "https://github.com/mergesort/Communicado.git",
+  "https://github.com/mflknr/SwiftVersionCompare.git",
   "https://github.com/mgadda/swift-parse.git",
   "https://github.com/mgrebenets/SwiftScriptRunner.git",
   "https://github.com/mhdhejazi/Dynamic.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftVersionCompare](https://github.com/mflknr/SwiftVersionCompare)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
