### PR TITLE
Adds AVFoundation-Combine

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1539,6 +1539,7 @@
   "https://github.com/josercc/SwiftTableViewGroup.git",
   "https://github.com/JoshHrach/ActivityIndicatorView.git",
   "https://github.com/Jounce/Surge.git",
+  "https://github.com/jozsef-vesza/AVFoundation-Combine",
   "https://github.com/jp-fan-app/swift-client.git",
   "https://github.com/jph00/basemath.git",
   "https://github.com/jpmhouston/RenameCommand.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [AVFoundation-Combine](https://github.com/jozsef-vesza/AVFoundation-Combine)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
