### PR TITLE
Added the Stripe iOS library

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3062,6 +3062,7 @@
   "https://github.com/stiivi/dotwriter.git",
   "https://github.com/stiivi/parsercombinator.git",
   "https://github.com/stoneburner/ShowSomeProgress.git",
+  "https://github.com/stripe/stripe-ios.git",
   "https://github.com/studio-rookery/timekit.git",
   "https://github.com/subito-it/bariloche.git",
   "https://github.com/sunlubo/swiftffmpeg.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Stripe iOS](https://github.com/stripe/stripe-ios)

## Checklist

I have either:

* [*] Run `swift ./validate.swift`.

Or, checked that:

* [*] The package repositories are publicly accessible.
* [*] The packages all contain a `Package.swift` file in the root folder.
* [*] The packages are written in Swift 4.0 or later.
* [*] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [*] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [*] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [*] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [~] The packages all compile without errors.
* [*] The package list JSON file is sorted alphabetically.
