### PR TITLE
add RevenueCat/purchases-ios

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2699,6 +2699,7 @@
   "https://github.com/ReSwift/ReSwift-Router.git",
   "https://github.com/ReSwift/ReSwift.git",
   "https://github.com/retailcrm/Fastis.git",
+  "https://github.com/RevenueCat/purchases-ios.git",
   "https://github.com/rexmas/Crust.git",
   "https://github.com/rexmas/JSONValue.git",
   "https://github.com/rhodgkins/SwiftHTTPStatusCodes.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://github.com/RevenueCat/purchases-ios)

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
