### PR TITLE
Added mochidev/DynamicCodable to the list

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2113,6 +2113,7 @@
   "https://github.com/MobileNativeFoundation/Kronos.git",
   "https://github.com/MobileNativeFoundation/set-simulator-location.git",
   "https://github.com/mochidev/Bytes.git",
+  "https://github.com/mochidev/DynamicCodable.git",
   "https://github.com/modswift/Apache.git",
   "https://github.com/modswift/CApache.git",
   "https://github.com/modswift/ExExpress.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [DynamicCodable](https://github.com/mochidev/DynamicCodable)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
