### PR TITLE
Added Farfetch/NetworkMonitor

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1057,6 +1057,7 @@
   "https://github.com/facebook/facebook-ios-sdk.git",
   "https://github.com/FamilySearch/sModel.git",
   "https://github.com/fanpyi/UICollectionViewLeftAlignedLayout-Swift.git",
+  "https://github.com/Farfetch/network-monitor-ios.git",
   "https://github.com/fassko/MeteoLVProvider.git",
   "https://github.com/fassko/TartuWeatherProvider.git",
   "https://github.com/fastlane/fastlane.git",


### PR DESCRIPTION
👋🏻 Hello there

The package(s) being submitted are:

* [NetworkMonitor](https://github.com/Farfetch/network-monitor-ios)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.


Thanks for building the Swift Package Index. Great idea!