### PR TITLE
Add intitni/Whatever and intitni/SmoothGradient

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1434,6 +1434,8 @@
   "https://github.com/Instabug/Instabug-SP.git",
   "https://github.com/Interactive-Studio/ISPageControl.git",
   "https://github.com/interstateone/binarycookies.git",
+  "https://github.com/intitni/SmoothGradient.git",
+  "https://github.com/intitni/Whatever.git",
   "https://github.com/iosdevzone/idzswiftdatataskpublisher.git",
   "https://github.com/ipavlidakis/PutioKit.git",
   "https://github.com/iSapozhnik/EventMonitor.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SmoothGradient](https://github.com/intitni/SmoothGradient)
* [Whatever](https://github.com/intitni/Whatever)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
