### PR TITLE
Added DigitalMasterpieces/CoreImageExtensions package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -853,6 +853,7 @@
   "https://github.com/Digipolitan/localization-toolkit.git",
   "https://github.com/Digipolitan/runtime-environment.git",
   "https://github.com/Digipolitan/session-kit.git",
+  "https://github.com/DigitalMasterpieces/CoreImageExtensions.git",
   "https://github.com/dimakura/sspec.git",
   "https://github.com/DimaRU/CDRCodable.git",
   "https://github.com/dimillian/swiftuiflux.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [CoreImageExtensions](https://github.com/DigitalMasterpieces/CoreImageExtensions)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
