### PR TITLE
Add LeoNatan/LNPropertyListEditor and LeoNatan/LNTouchVisualizer packages

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1843,6 +1843,7 @@
   "https://github.com/LeoNatan/LNPopupController.git",
   "https://github.com/LeoNatan/LNPopupUI.git",
   "https://github.com/LeoNatan/LNPropertyListEditor.git",
+  "https://github.com/LeoNatan/LNTouchVisualizer.git",
   "https://github.com/lexrus/MMDB-Swift.git",
   "https://github.com/liam923/MathKit.git",
   "https://github.com/ligr/appkit.git",

--- a/packages.json
+++ b/packages.json
@@ -1842,6 +1842,7 @@
   "https://github.com/lennet/symbols.git",
   "https://github.com/LeoNatan/LNPopupController.git",
   "https://github.com/LeoNatan/LNPopupUI.git",
+  "https://github.com/LeoNatan/LNPropertyListEditor.git",
   "https://github.com/lexrus/MMDB-Swift.git",
   "https://github.com/liam923/MathKit.git",
   "https://github.com/ligr/appkit.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [LNPropertyListEditor](https://github.com/LeoNatan/LNPropertyListEditor)
* [LNTouchVisualizer](https://github.com/LeoNatan/LNTouchVisualizer)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
