### PR TITLE
Add SourceMapper

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1536,6 +1536,7 @@
   "https://github.com/johnbona/disque.git",
   "https://github.com/JohnEstropia/CoreStore.git",
   "https://github.com/johnfairh/RubyGateway.git",
+  "https://github.com/johnfairh/SourceMapper.git",
   "https://github.com/johnfairh/swift-sass.git",
   "https://github.com/johnfairh/TMLPersistentContainer.git",
   "https://github.com/johnno1962/DLKit.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SourceMapper](https://github.com/johnfairh/SourceMapper/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
