### PR TITLE
Add `CypherPoet/SwiftUIPreviewUtils`

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -684,6 +684,7 @@
   "https://github.com/CypherPoet/ModulusOperandi.git",
   "https://github.com/CypherPoet/SwiftUICurvedRectangleShape.git",
   "https://github.com/CypherPoet/SwiftUIPolygon.git",
+  "https://github.com/CypherPoet/SwiftUIPreviewUtils.git",
   "https://github.com/CypherPoet/SwiftUISineWaveShape.git",
   "https://github.com/CypherPoet/SwiftUIWavyRectangleShape.git",
   "https://github.com/dadalar/SwiftUI-CardStackView.git",


### PR DESCRIPTION
The package(s) being submitted are:

https://github.com/CypherPoet/SwiftUIPreviewUtils.

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
