### PR TITLE
Add FSCheckoutSheet

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3683,6 +3683,7 @@
   "https://github.com/ZeeQL/ZeeQL3Combine.git",
   "https://github.com/ZeeQL/ZeeQL3Freddy.git",
   "https://github.com/ZeeQL/ZeeQL3PG.git",
+  "https://github.com/ZeeZide/FSCheckoutSheet.git",
   "https://github.com/ZeeZide/SVGWebView.git",
   "https://github.com/Zewo/Venice.git",
   "https://github.com/Zewo/zewo.git",


### PR DESCRIPTION
This package provides a nice wrapper for the FastSpring online commerce checkout (i.e. for selling macOS apps
on FastSpring).

The package(s) being submitted are:

* [FSCheckoutSheet](https://github.com/ZeeZide/FSCheckoutSheet/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
