### PR TITLE
Added swift-lens

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -419,6 +419,7 @@
   "https://github.com/bielikb/UIViewPreview.git",
   "https://github.com/bielikb/UseAutoLayout.git",
   "https://github.com/bigMOTOR/DataDrivenRxDatasources.git",
+  "https://github.com/bigMOTOR/swift-lens.git",
   "https://github.com/bignerdranch/Deferred.git",
   "https://github.com/Bilue/ContentFittingWebView.git",
   "https://github.com/BinaryBirds/build-kit.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [swift-lens](https://github.com/bigMOTOR/swift-lens)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
