### PR TITLE
Add CPIOArchiveKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1866,6 +1866,7 @@
   "https://github.com/leacode/Earth.git",
   "https://github.com/leavez/Mappable.git",
   "https://github.com/LebJe/ArArchiveKit.git",
+  "https://github.com/LebJe/CPIOArchiveKit.git",
   "https://github.com/leeceny/perfect-qiniu.git",
   "https://github.com/leixjin/WC-Swift.git",
   "https://github.com/lennet/flamegraph.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [CPIOArchiveKit](https://github.com/LebJe/CPIOArchiveKit.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
