### PR TITLE
Add WriteFreely Swift Package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3608,6 +3608,7 @@
   "https://github.com/workingDog/OWOneCall.git",
   "https://github.com/woxtu/NSString-RemoveEmoji.git",
   "https://github.com/woxtu/RouteKit.git",
+  "https://github.com/writefreely/writefreely-swift.git",
   "https://github.com/wtw-software/UTMConversion.git",
   "https://github.com/wulkano/Aperture.git",
   "https://github.com/WXKDarkSky/WXKDarkSky.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [WriteFreely](https://github.com/writefreely/writefreely-swift/)

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
