### PR TITLE
Added SettingsBundleBuilder package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -389,6 +389,7 @@
   "https://github.com/bengottlieb/marcel.git",
   "https://github.com/bengottlieb/plug.git",
   "https://github.com/benjaminmayo/sass-swift.git",
+  "https://github.com/benrobinson16/SettingsBundleBuilder.git",
   "https://github.com/benspratling4/swiftawss3.git",
   "https://github.com/benspratling4/swiftawssignaturev4.git",
   "https://github.com/benspratling4/swiftfoundationcompression.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SettingsBundleBuilder](https://github.com/benrobinson16/SettingsBundleBuilder)

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [X] The package repositories are publicly accessible.
* [X] The packages all contain a `Package.swift` file in the root folder.
* [X] The packages are written in Swift 4.0 or later.
* [X] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [X] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [X] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [X] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [X] The packages all compile without errors.
* [X] The package list JSON file is sorted alphabetically.
