### PR TITLE
Add Bazooka package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -829,6 +829,7 @@
   "https://github.com/denissimon/prediction-builder-swift.git",
   "https://github.com/denizcoskun/RxStore.git",
   "https://github.com/dennisbirch/simple-analytics.git",
+  "https://github.com/denniscm190/Bazooka.git",
   "https://github.com/denniscm190/StockCharts.git",
   "https://github.com/DenTelezhkin/Ariadne.git",
   "https://github.com/DenTelezhkin/DTCollectionViewManager.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Bazooka](https://github.com/denniscm190/Bazooka)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
