### PR TITLE
Add Apexy, Catbird, GoldenKey

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2740,6 +2740,7 @@
   "https://github.com/realm/realm-core.git",
   "https://github.com/realm/SwiftLint.git",
   "https://github.com/ReCombine/ReCombine.git",
+  "https://github.com/RedMadRobot/apexy-ios.git",
   "https://github.com/RedMadRobot/autograph.git",
   "https://github.com/RedMadRobot/input-mask-ios.git",
   "https://github.com/RedMadRobot/parser-autograph.git",

--- a/packages.json
+++ b/packages.json
@@ -2742,6 +2742,8 @@
   "https://github.com/ReCombine/ReCombine.git",
   "https://github.com/RedMadRobot/apexy-ios.git",
   "https://github.com/RedMadRobot/autograph.git",
+  "https://github.com/RedMadRobot/catbird.git",
+  "https://github.com/RedMadRobot/golden-key.git",
   "https://github.com/RedMadRobot/input-mask-ios.git",
   "https://github.com/RedMadRobot/parser-autograph.git",
   "https://github.com/RedMadRobot/service-autograph.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Apexy](https://github.com/RedMadRobot/apexy-ios)
* [Catbird](https://github.com/RedMadRobot/catbird)
* [GoldenKey](https://github.com/RedMadRobot/golden-key)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
