### PR TITLE
Add currency-converter package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2586,6 +2586,7 @@
   "https://github.com/pixelspark/catena.git",
   "https://github.com/pixelspark/postgres-wire-server.git",
   "https://github.com/pixelspark/sqlite.git",
+  "https://github.com/pixyzehn/currency-converter.git",
   "https://github.com/pjechris/AnnotationInject.git",
   "https://github.com/pkrll/SwiftArgs.git",
   "https://github.com/pksprojects/ElasticSwift.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [currency-converter](https://github.com/pixyzehn/currency-converter)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 4.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
