### PR TITLE
Change the minimum Swift version for packages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ Or, checked that:
 
 * [ ] The package repositories are publicly accessible.
 * [ ] The packages all contain a `Package.swift` file in the root folder.
-* [ ] The packages are written in Swift 4.0 or later.
+* [ ] The packages are written in Swift 5.0 or later.
 * [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
 * [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
 * [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you would prefer to validate the requirements manually, please verify that:
 
 * The package repositories are all publicly accessible.
 * The packages all contain a `Package.swift` file in the root folder.
-* The packages are written in Swift 4.0 or later.
+* The packages are written in Swift 5.0 or later.
 * The packages all contain at least one product (either library or executable), and at least one product must be usable in other Swift apps.
 * The packages all have at least one release tagged as a [semantic version](https://semver.org/).
 * The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.


### PR DESCRIPTION
We don't check this explicitly, but we should provide this as an indicator of what's reasonable and what we test with.

I don't think we should force a check for this, as packages as far back as Swift 4.0 do support `dump-package` and so the index will cope with them, so the guidance update is all that's needed.