### PR TITLE
Add 'pusher-http-swift' package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2673,6 +2673,7 @@
   "https://github.com/pureswift/tlvcoding.git",
   "https://github.com/pusher/NWWebSocket.git",
   "https://github.com/pusher/push-notifications-server-swift.git",
+  "https://github.com/pusher/pusher-http-swift.git",
   "https://github.com/pusher/pusher-websocket-swift.git",
   "https://github.com/pvieito/LoggerKit.git",
   "https://github.com/pvieito/PythonKit.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [pusher-http-swift](https://github.com/pusher/pusher-http-swift)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 4.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
