### PR TITLE
add SAP/cloud-sdk-ios-cai package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2925,6 +2925,7 @@
   "https://github.com/samnung/Weekday.swift.git",
   "https://github.com/sanzaru/csvkit.git",
   "https://github.com/sanzaru/SimpleToast.git",
+  "https://github.com/SAP/cloud-sdk-ios-cai.git",
   "https://github.com/SAP/cloud-sdk-ios-fiori.git",
   "https://github.com/satanwoo/wzqinstantsearch.git",
   "https://github.com/satishbabariya/SwiftyContacts.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [cloud-sdk-ios-cai](https://github.com/SAP/cloud-sdk-ios-cai)

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
