### PR TITLE
Added Resolver package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1390,6 +1390,7 @@
   "https://github.com/hjuraev/nats-swift.git",
   "https://github.com/hjuraev/vapornotifications.git",
   "https://github.com/hkellaway/Gloss.git",
+  "https://github.com/hmlongco/Resolver.git",
   "https://github.com/hmlongco/RxSwiftForms.git",
   "https://github.com/holiday-jp/holiday_jp-swift.git",
   "https://github.com/holzschu/ios_system.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Resolver](https://github.com/hmlongco/Resolver)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
