### PR TITLE
Add nativedevbr/swift-log package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2246,6 +2246,7 @@
   "https://github.com/naoty/flock.git",
   "https://github.com/naoty/Timepiece.git",
   "https://github.com/nashysolutions/DocSlice.git",
+  "https://github.com/nativedevbr/swift-log.git",
   "https://github.com/natmark/donut.git",
   "https://github.com/nbasham/BlackLabsSwiftUIColor.git",
   "https://github.com/nbasham/CloudUserDefaults.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [swift-log](https://github.com/nativedevbr/swift-log)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
