### PR TITLE
Add jmespath.swift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -45,6 +45,7 @@
   "https://github.com/adam-fowler/big-num.git",
   "https://github.com/adam-fowler/compress-nio.git",
   "https://github.com/adam-fowler/dictionary-encoder.git",
+  "https://github.com/adam-fowler/jmespath.swift.git",
   "https://github.com/adam-fowler/mqtt-nio.git",
   "https://github.com/adam-fowler/s3-filesystem-kit.git",
   "https://github.com/adam-fowler/swift-srp.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [JMESPath](https://github.com/adam-fowler/jmespath.swift.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
