### PR TITLE
add SAP/cloud-sdk-ios-fioriarkit package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2949,6 +2949,7 @@
   "https://github.com/sanzaru/SimpleToast.git",
   "https://github.com/SAP/cloud-sdk-ios-cai.git",
   "https://github.com/SAP/cloud-sdk-ios-fiori.git",
+  "https://github.com/SAP/cloud-sdk-ios-fioriarkit.git",
   "https://github.com/satanwoo/wzqinstantsearch.git",
   "https://github.com/satishbabariya/SwiftyContacts.git",
   "https://github.com/sbader/fragmentedmp4parser.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [FioriARKit](https://github.com/SAP/cloud-sdk-ios-fioriarkit)

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
