### PR TITLE
Added RougeWare's `RangeTools`

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2868,6 +2868,7 @@
   "https://github.com/RougeWare/Swift-Lazy-Containers.git",
   "https://github.com/RougeWare/Swift-MultiplicativeArithmetic.git",
   "https://github.com/RougeWare/Swift-Optional-Tools.git",
+  "https://github.com/RougeWare/Swift-Range-Tools.git",
   "https://github.com/RougeWare/Swift-Rectangle-Tools.git",
   "https://github.com/RougeWare/Swift-Safe-Collection-Access.git",
   "https://github.com/RougeWare/Swift-SemVer.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [RangeTools](https://github.com/RougeWare/Swift-Range-Tools) - A small package which makes ranges easier to work with


## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
