### PR TITLE
Add Plotly.swift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3589,6 +3589,7 @@
   "https://github.com/vknabel/Finite.git",
   "https://github.com/VladimirBrejcha/LoadingView.git",
   "https://github.com/VladimirBrejcha/SelectableStackView.git",
+  "https://github.com/vojtamolda/Plotly.swift.git",
   "https://github.com/voynovia/jrpcswiftnio.git",
   "https://github.com/vtourraine/acknowlist.git",
   "https://github.com/vtourraine/thirdpartymailer.git",


### PR DESCRIPTION
The package being submitted are:

* [Plotly.swift](https://github.com/vojtamolda/Plotly.swift)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
