### PR TITLE
Add SwiftlySearch

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3376,6 +3376,7 @@
   "https://github.com/thii/Unxip.git",
   "https://github.com/thii/xcbeautify.git",
   "https://github.com/thii/yes.git",
+  "https://github.com/thislooksfun/SwiftlySearch.git",
   "https://github.com/Thomvis/BrightFutures.git",
   "https://github.com/thoughtbot/Argo.git",
   "https://github.com/thoughtbot/CombineViewModel.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftlySearch](https://github.com/thislooksfun/SwiftlySearch)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.

---

Note: SwiftlySearch is obsolete, and thus deprecated, in iOS 15.
It will still work, and will continue to exist for apps that require
support for iOS 13 or 14, but it should not be used in applications
targeting iOS 15 or later. They should instead use the new
[`.searchable()`][searchable] modifier, which is native and also
works cross-platform.

[searchable]: https://developer.apple.com/documentation/swiftui/form/searchable(text:placement:)