### PR TITLE
Added adamayoung/UKPoliceData package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -51,6 +51,7 @@
   "https://github.com/adam-fowler/swift-srp.git",
   "https://github.com/adam-fowler/xml-coding.git",
   "https://github.com/adamayoung/TMDb.git",
+  "https://github.com/adamayoung/UKPoliceData.git",
   "https://github.com/adamcichy/SwiftySound.git",
   "https://github.com/adamnemecek/phantomlike.git",
   "https://github.com/adamnemecek/webmidikit.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [UKPoliceData](https://github.com/adamayoung/UKPoliceData)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
