### PR TITLE
Temporarily remove LeftPad

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -803,7 +803,6 @@
   "https://github.com/davedelong/DDMathParser.git",
   "https://github.com/davedelong/time.git",
   "https://github.com/davedufresne/SwiftParsec.git",
-  "https://github.com/daveverwer/LeftPad.git",
   "https://github.com/DaveWoodCom/XCGLogger.git",
   "https://github.com/david-livadaru/DLAngle.git",
   "https://github.com/david-livadaru/DLCoreGraphics.git",


### PR DESCRIPTION
I need to record a video of adding a package, so this will need to be removed for a while!