### PR TITLE
Add JosephDuffy/VaporDocC.git

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1638,6 +1638,7 @@
   "https://github.com/JosephDuffy/Partial.git",
   "https://github.com/JosephDuffy/Persist.git",
   "https://github.com/JosephDuffy/SwiftChecksDangerPlugin.git",
+  "https://github.com/JosephDuffy/VaporDocC.git",
   "https://github.com/josephlord/FMZDropInMinimalFacebookLogin.git",
   "https://github.com/josephlord/MicroInjection.git",
   "https://github.com/josercc/SwiftTableViewGroup.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [VaporDocC](https://github.com/JosephDuffy/VaporDocC)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
