### PR TITLE
Add promotedai/ios-metrics-sdk

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2680,6 +2680,7 @@
   "https://github.com/priteshrnandgaonkar/atlas.git",
   "https://github.com/ProcedureKit/ProcedureKit.git",
   "https://github.com/profburke/swiftreplmadness.git",
+  "https://github.com/promotedai/ios-metrics-sdk.git",
   "https://github.com/Pronto-am/MobileCMS-iOS-SDK.git",
   "https://github.com/provideplatform/provide-swift.git",
   "https://github.com/ProxymanApp/atlantis.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Promoted.ai iOS Metrics SDK](https://github.com/promotedai/ios-metrics-sdk.git)

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
