### PR TITLE
Adding two packages

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1637,6 +1637,8 @@
   "https://github.com/jonasman/TeslaSwift.git",
   "https://github.com/JonathanDowning/SwiftMETAR.git",
   "https://github.com/jonkykong/SideMenu.git",
+  "https://github.com/joogps/IrregularGradient.git",
+  "https://github.com/joogps/SlideOverCard.git",
   "https://github.com/josefdolezal/ignorio.git",
   "https://github.com/josefdolezal/xcman.git",
   "https://github.com/JosephDuffy/HashableByKeyPath.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [IrregularGradient](https://github.com/joogps/IrregularGradient)
* [SlideOverCard](https://github.com/joogps/SlideOverCard)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
