### PR TITLE
Add swift-string-transform

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3498,6 +3498,7 @@
   "https://github.com/typelift/Swiftz.git",
   "https://github.com/uber/RIBs.git",
   "https://github.com/ucotta/brillianthtml5parser.git",
+  "https://github.com/uhooi/swift-string-transform.git",
   "https://github.com/uias/Pageboy.git",
   "https://github.com/uias/Tabman.git",
   "https://github.com/ukitaka/XCTAssertUnrecoverable.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [swift-string-transform](https://github.com/uhooi/swift-string-transform)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
