### PR TITLE
Add HPParallaxHeader

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2329,6 +2329,7 @@
   "https://github.com/NextLevel/NextLevel.git",
   "https://github.com/NextLevel/NextLevelSessionExporter.git",
   "https://github.com/ngeri/accessible.git",
+  "https://github.com/ngochiencse/HPParallaxHeader.git",
   "https://github.com/ngtk/LoggerKit.git",
   "https://github.com/nh7a/geohash.git",
   "https://github.com/nhoogendoorn/CardStack.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [HPParallaxHeader](https://github.com/ngochiencse/HPParallaxHeader)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
