### PR TITLE
Add sebj/Steam and sebj/swiftui-matched-inline-title

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3035,6 +3035,8 @@
   "https://github.com/seanparsons/swifttrycatch.git",
   "https://github.com/sebastianpixel/dependencyinjection.git",
   "https://github.com/sebastianpixel/dynamiccodable.git",
+  "https://github.com/sebj/Steam.git",
+  "https://github.com/sebj/swiftui-matched-inline-title.git",
   "https://github.com/segabor/osccore.git",
   "https://github.com/segmentio/analytics-swift.git",
   "https://github.com/sendyhalim/Swime.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Steam](https://github.com/sebj/Steam)
* [swiftui-matched-inline-title](https://github.com/sebj/swiftui-matched-inline-title)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
