### PR TITLE
Add SshConfig package.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3712,6 +3712,7 @@
   "https://github.com/xmartlabs/Eureka.git",
   "https://github.com/xspyhack/ditto.git",
   "https://github.com/xwu/NumericAnnex.git",
+  "https://github.com/xxlabaza/SshConfig.git",
   "https://github.com/y-ich/swift-sgf.git",
   "https://github.com/yacir/CollectionViewSlantedLayout.git",
   "https://github.com/yagiz/Bagel.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SshConfig](https://github.com/xxlabaza/SshConfig)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
