### PR TITLE
added-swiftwidgets

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2479,6 +2479,7 @@
   "https://github.com/omaralbeik/Drops.git",
   "https://github.com/omaralbeik/UserDefaultsStore.git",
   "https://github.com/omeasraf/SFIcons.git",
+  "https://github.com/omeasraf/SwiftWidgets.git",
   "https://github.com/omerfarukozturk/UIView-Shimmer.git",
   "https://github.com/omichde/AttributedText.git",
   "https://github.com/omochi/bitcodeformat.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftWidgets](https://github.com/omeasraf/SwiftWidgets)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
