### PR TITLE
Add SpacedRepetitionScheduler

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -390,6 +390,7 @@
   "https://github.com/Bayer-Group/TimberSwift.git",
   "https://github.com/bazaarvoice/bv-ios-swift-sdk.git",
   "https://github.com/bdewey/BookKit.git",
+  "https://github.com/bdewey/SpacedRepetitionScheduler.git",
   "https://github.com/bdewey/TextMarkupKit.git",
   "https://github.com/BeAppOnline/AFBilling.git",
   "https://github.com/BeAppOnline/AFNetwork.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SpacedRepetitionScheduler](https://github.com/bdewey/SpacedRepetitionScheduler)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

```
Processing package list ...
+ https://github.com/bdewey/SpacedRepetitionScheduler.git
✅ validation succeeded
```

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
