### PR TITLE
Added Keychain

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1479,6 +1479,7 @@
   "https://github.com/ibm-cloud-security/appid-serversdk-swift.git",
   "https://github.com/ibm-cloud-security/swift-jwk-to-pem.git",
   "https://github.com/IBM-Swift/alert-notification-sdk.git",
+  "https://github.com/IBM/ios-keychain.git",
   "https://github.com/IBM/swift-sdk-core.git",
   "https://github.com/icanzilb/Cancellor.git",
   "https://github.com/icanzilb/RxTimelane.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Keychain](https://github.com/IBM/ios-keychain)

## Checklist

I have either:

* [* ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
