### PR TITLE
Add Axx to the list of packages

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1074,6 +1074,7 @@
   "https://github.com/emorydunn/launchagent.git",
   "https://github.com/emorydunn/SwiftGraphics.git",
   "https://github.com/emqx/CocoaMQTT.git",
+  "https://github.com/eneko/axx.git",
   "https://github.com/eneko/DateTemplates.git",
   "https://github.com/eneko/github.git",
   "https://github.com/eneko/kebab.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Axx](https://github.com/eneko/Axx)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
