### PR TITLE
Add swift-identified-collections

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2709,6 +2709,7 @@
   "https://github.com/pointfreeco/swift-html-kitura.git",
   "https://github.com/pointfreeco/swift-html-vapor.git",
   "https://github.com/pointfreeco/swift-html.git",
+  "https://github.com/pointfreeco/swift-identified-collections.git",
   "https://github.com/pointfreeco/swift-nonempty.git",
   "https://github.com/pointfreeco/swift-overture.git",
   "https://github.com/pointfreeco/swift-parsing.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Identified Collections](https://github.com/pointfreeco/swift-identified-collections)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
