### PR TITLE
Add https://github.com/stevengharris/MarkupEditor

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3263,6 +3263,7 @@
   "https://github.com/stendahls/Taskig.git",
   "https://github.com/stenographer/stenographer.git",
   "https://github.com/stephencelis/SQLite.swift.git",
+  "https://github.com/stevengharris/MarkupEditor.git",
   "https://github.com/stiivi/dotwriter.git",
   "https://github.com/stiivi/parsercombinator.git",
   "https://github.com/stoneburner/ShowSomeProgress.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [MarkupEditor](https://github.com/stevengharris/MarkupEditor)

## Checklist

I have either:

* [X ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
