### PR TITLE
Add swift-log-SwiftyBeaver

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3181,6 +3181,7 @@
   "https://github.com/shirokova/bottomsheet-swiftui.git",
   "https://github.com/shiroyagicorp/swift-seeurl.git",
   "https://github.com/ShitLib/shitlib-swift.git",
+  "https://github.com/ShivaHuang/swift-log-SwiftyBeaver.git",
   "https://github.com/shogo4405/HaishinKit.swift.git",
   "https://github.com/shogo4405/Logboard.git",
   "https://github.com/shogo4405/usage.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [LoggingSwiftyBeaver](https://github.com/ShivaHuang/swift-log-SwiftyBeaver)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
