### PR TITLE
Add StormGlass API

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -725,6 +725,7 @@
   "https://github.com/crspybits/CredentialsDropbox.git",
   "https://github.com/crspybits/CredentialsMicrosoft.git",
   "https://github.com/crspybits/SwiftyAWSSNS.git",
+  "https://github.com/cruisea-app/stormglass-swift.git",
   "https://github.com/cryptomator/cloud-access-swift.git",
   "https://github.com/cryptomator/cryptolib-swift.git",
   "https://github.com/cs4alhaider/Helper4Swift.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
