### PR TITLE
add TactileSlider

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -827,6 +827,7 @@
   "https://github.com/danramteke/MPath.git",
   "https://github.com/danramteke/swish.git",
   "https://github.com/dapperstout/swift-bytes.git",
+  "https://github.com/daprice/iOS-Tactile-Slider.git",
   "https://github.com/darjeelingsteve/hopoate.git",
   "https://github.com/Darkngs/DECardNumberFormatter.git",
   "https://github.com/Darkngs/DEPhoneNumberFormatter.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [TactileSlider](https://github.com/daprice/iOS-Tactile-Slider)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
