### PR TITLE
Add Custom Dump

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2755,6 +2755,7 @@
   "https://github.com/pointfreeco/composable-core-motion.git",
   "https://github.com/pointfreeco/swift-case-paths.git",
   "https://github.com/pointfreeco/swift-composable-architecture.git",
+  "https://github.com/pointfreeco/swift-custom-dump.git",
   "https://github.com/pointfreeco/swift-gen.git",
   "https://github.com/pointfreeco/swift-html-vapor.git",
   "https://github.com/pointfreeco/swift-html.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://github.com/pointfreeco/swift-custom-dump)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
