### PR TITLE
Add CombineCoreBluetooth library

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3312,6 +3312,7 @@
   "https://github.com/ssamadgh/ModelAssistant.git",
   "https://github.com/sstadelman/observable-array.git",
   "https://github.com/stablekernel/DataViewable.git",
+  "https://github.com/StarryInternet/CombineCoreBluetooth.git",
   "https://github.com/StatusQuo/InjectKit.git",
   "https://github.com/staykids/Cully.git",
   "https://github.com/std-swift/Encoding.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [CombineCoreBluetooth](https://github.com/StarryInternet/CombineCoreBluetooth)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
