### PR TITLE
Add observed-optional-object

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1262,6 +1262,7 @@
   "https://github.com/FormatterKit/DayPeriodFormatter.git",
   "https://github.com/foulkesjohn/betswift.git",
   "https://github.com/foulkesjohn/csvencoder.git",
+  "https://github.com/fourplusone/observed-optional-object.git",
   "https://github.com/fourplusone/rasterize.git",
   "https://github.com/fourplusone/TerraformKit.git",
   "https://github.com/franklefebvre/xmlcoder.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [ObservedOptionalObject](https://github.com/fourplusone/observed-optional-object)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
