### PR TITLE
Add rogerluan/JSEN and rogerluan/SwiftttCamera

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2999,6 +2999,8 @@
   "https://github.com/rockfordwei/perfect-ini.git",
   "https://github.com/rockfordwei/perfect-pcre2.git",
   "https://github.com/rockfordwei/perfect-squishy.git",
+  "https://github.com/rogerluan/JSEN.git",
+  "https://github.com/rogerluan/SwiftttCamera.git",
   "https://github.com/romiroma/BroadcastWriter.git",
   "https://github.com/ronanrodrigo/Frisbee.git",
   "https://github.com/RougeWare/Efficient-Averager.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [JSEN](https://github.com/rogerluan/JSEN)
* [SwiftttCamera](https://github.com/rogerluan/SwiftttCamera)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
