### PR TITLE
Add swifty-nats, a community driven client for NATS

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -363,6 +363,7 @@
   "https://github.com/AudioKit/SoundpipeAudioKit.git",
   "https://github.com/AudioKit/SporthAudioKit.git",
   "https://github.com/AudioKit/STKAudioKit.git",
+  "https://github.com/aus-der-Technik/swifty-nats.git",
   "https://github.com/auth0/JWTDecode.swift.git",
   "https://github.com/autimatisering/AMKit.git",
   "https://github.com/autobahnswift/shuttle.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [swifty-nats](https://github.com/aus-der-Technik/swifty-nats)

## Checklist

I have either:

* 

- [x]  Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
