### PR TITLE
Add SwiftMicroPNG

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2900,6 +2900,7 @@
   "https://github.com/rb-de0/linuxmaingen.git",
   "https://github.com/rb-de0/Poppo.git",
   "https://github.com/rb-de0/yubatake.git",
+  "https://github.com/rbruinier/SwiftMicroPNG.git",
   "https://github.com/rderik/Cncurses.git",
   "https://github.com/ReactiveCocoa/ReactiveSwift.git",
   "https://github.com/ReactiveX/RxSwift.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftMicroPNG]( "https://github.com/rbruinier/SwiftMicroPNG.git")

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
