### PR TITLE
Add MarkdownChildrenKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2658,6 +2658,7 @@
   "https://github.com/patchthecode/JTAppleCalendar.git",
   "https://github.com/patgoley/Configurate.git",
   "https://github.com/patrickbdev/ACDD-Swift.git",
+  "https://github.com/patrickbdev/MarkdownChildrenKit.git",
   "https://github.com/pauljeannot/swiftybash.git",
   "https://github.com/paulpela/BasketballJerseyNumber.git",
   "https://github.com/paulw11/Seam3.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [MarkdownChildrenKit](https://github.com/patrickbdev/MarkdownChildrenKit/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
