### PR TITLE
Added Apple Watch Decimal Keypad to packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -283,6 +283,7 @@
   "https://github.com/apple/swift-tools-support-async.git",
   "https://github.com/apple/swift-tools-support-core.git",
   "https://github.com/apple/swiftpm-on-llbuild2.git",
+  "https://github.com/ApplebaumIan/SwiftUI-Apple-Watch-Decimal-Pad.git",
   "https://github.com/appoly/AtlasKit.git",
   "https://github.com/appoly/PassportKit.git",
   "https://github.com/apppear/chartview.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftUI-Apple-Watch-Decimal-Pad](https://github.com/ApplebaumIan/SwiftUI-Apple-Watch-Decimal-Pad)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
