### PR TITLE
Add ctreffs/SwiftSDL2

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -757,6 +757,7 @@
   "https://github.com/cszatmary/SwiftySweetness.git",
   "https://github.com/ctreffs/SwiftAssimp.git",
   "https://github.com/ctreffs/SwiftImGui.git",
+  "https://github.com/ctreffs/SwiftSDL2.git",
   "https://github.com/ctreffs/SwiftSimctl.git",
   "https://github.com/cuba/mongoorm.git",
   "https://github.com/CUITCHE/UserCaches.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftSDL2](https://github.com/SwiftSDL2) - a [SDL2](https://www.libsdl.org) wrapper with macOS, Linux and Windows support

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
