### PR TITLE
Adding square/Blueprint

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3331,6 +3331,7 @@
   "https://github.com/splitio/ios-client.git",
   "https://github.com/spotify/Mobius.swift.git",
   "https://github.com/spropensource/ArchitectureComponents.git",
+  "https://github.com/square/Blueprint.git",
   "https://github.com/square/Cleanse.git",
   "https://github.com/square/StringTemplate.git",
   "https://github.com/square/Valet.git",


### PR DESCRIPTION
The package being submitted is:

* [Blueprint](https://github.com/square/Blueprint)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
