### PR TITLE
added xcresultparser swift package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -35,6 +35,7 @@
   "https://github.com/8rightside/Resistance.git",
   "https://github.com/a2/MessagePack.swift.git",
   "https://github.com/a2/swift-shortcuts.git",
+  "https://github.com/a7ex/xcresultparser.git",
   "https://github.com/aaastorga/darksky-provider.git",
   "https://github.com/AaronBratcher/AgileDB.git",
   "https://github.com/aaronsky/buildkite-swift.git",


### PR DESCRIPTION
xcresultparser parses xcresult files and outputs colored CLI, xml or html for coverage and tests

The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
