### PR TITLE
Add dscyrescotti/ReachabilityX

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1035,6 +1035,7 @@
   "https://github.com/drichardson/SwiftyBase64.git",
   "https://github.com/drmohundro/SWXMLHash.git",
   "https://github.com/dscyrescotti/CodableX.git",
+  "https://github.com/dscyrescotti/ReachabilityX.git",
   "https://github.com/dtaylor1701/xcsnippets.git",
   "https://github.com/duemunk/async.git",
   "https://github.com/DuetHealth/Bedrock.git",


### PR DESCRIPTION
The package being submitted is:

* [ReachabilityX](https://github.com/dscyrescotti/ReachabilityX)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
