### PR TITLE
Add YouTubePlayerKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3393,6 +3393,7 @@
   "https://github.com/SvenTiigi/EUDCCKit.git",
   "https://github.com/sventiigi/swiftkit.git",
   "https://github.com/SvenTiigi/WhatsNewKit.git",
+  "https://github.com/SvenTiigi/YouTubePlayerKit.git",
   "https://github.com/SVGKit/SVGKit.git",
   "https://github.com/sweetclimusic/MyLibrary.git",
   "https://github.com/swhitty/DictionaryDecoder.git",


### PR DESCRIPTION
https://github.com/SvenTiigi/YouTubePlayerKit.git

The package(s) being submitted are:

* [YouTubePlayerKit](https://github.com/SvenTiigi/YouTubePlayerKit)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
