### PR TITLE
Add DigiMeSDK

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -962,6 +962,7 @@
   "https://github.com/dhardiman/fetch.git",
   "https://github.com/dhardiman/router.git",
   "https://github.com/dhardiman/spot.git",
+  "https://github.com/digime/digime-sdk-ios.git",
   "https://github.com/Digipolitan/alamofire-logging.git",
   "https://github.com/Digipolitan/dependency-injector-object-mapper.git",
   "https://github.com/Digipolitan/dependency-injector.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [DigiMeSDK](https://github.com/digime/digime-sdk-ios)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
