### PR TITLE
Add iOSSnapshotTestCase.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3681,6 +3681,7 @@
   "https://github.com/typelift/SwiftCheck.git",
   "https://github.com/typelift/Swiftx.git",
   "https://github.com/typelift/Swiftz.git",
+  "https://github.com/uber/ios-snapshot-test-case.git",
   "https://github.com/uber/RIBs.git",
   "https://github.com/ucotta/brillianthtml5parser.git",
   "https://github.com/uhooi/swift-http-client.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [iOSSnapshotTestCase](https://github.com/uber/ios-snapshot-test-case.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
