### PR TITLE
Add `christopherweems/_AsyncParsableCommand`

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -645,6 +645,7 @@
   "https://github.com/ChrisMash/ProvisioningProfile.git",
   "https://github.com/chrispomeroyhale/csv-dialect-swift.git",
   "https://github.com/christiankm/FinanceKit.git",
+  "https://github.com/christopherweems/_AsyncParsableCommand.git",
   "https://github.com/christopherweems/Resultto.git",
   "https://github.com/christopherweems/Sight.git",
   "https://github.com/christopherweems/triple-q.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [_AsyncParsableCommand](https://github.com/christopherweems/_AsyncParsableCommand)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
