### PR TITLE
Add SwiftUIPhone, WelcomeWindow

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1777,6 +1777,8 @@
   "https://github.com/juri/graphqler.git",
   "https://github.com/justinm1/s3signeraws.git",
   "https://github.com/justmaku/symbolic.git",
+  "https://github.com/JUSTINMKAUFMAN/SwiftUIPhone.git",
+  "https://github.com/JUSTINMKAUFMAN/WelcomeWindow.git",
   "https://github.com/jverdi/JVFloatLabeledTextField.git",
   "https://github.com/jverkoey/BinaryCodable.git",
   "https://github.com/k-o-d-e-n/CGLayout.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftUIPhone](https://github.com/JUSTINMKAUFMAN/SwiftUIPhone/)
* [WelcomeWindow](https://github.com/JUSTINMKAUFMAN/WelcomeWindow/)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [X] The package repositories are publicly accessible.
* [X] The packages all contain a `Package.swift` file in the root folder.
* [X] The packages are written in Swift 5.0 or later.
* [X] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [X] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [X] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [X] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [X] The packages all compile without errors.
* [X] The package list JSON file is sorted alphabetically.
