### PR TITLE
Added SwiftCPUDetect by ITzTravelInTime.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1614,6 +1614,7 @@
   "https://github.com/ishkawa/dikit.git",
   "https://github.com/isotopsweden/endpoints.git",
   "https://github.com/istvan-kreisz/CombineReachability.git",
+  "https://github.com/ITzTravelInTime/SwiftCPUDetect.git",
   "https://github.com/ivanlisovyi/Dep.git",
   "https://github.com/ivlevAstef/DITranquillity.git",
   "https://github.com/ivlevAstef/SwiftLazy.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftCPUDetect](https://github.com/ITzTravelInTime/SwiftCPUDetect)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [1.3.0](https://github.com/ITzTravelInTime/SwiftCPUDetect/releases/tag/1.3.0).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
