### PR TITLE
added what3words packages

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3864,6 +3864,8 @@
   "https://github.com/WeTransfer/GitBuddy.git",
   "https://github.com/WeTransfer/Mocker.git",
   "https://github.com/WeTransfer/WeTransfer-Swift-SDK.git",
+  "https://github.com/what3words/w3w-swift-components.git",
+  "https://github.com/what3words/w3w-swift-wrapper.git",
   "https://github.com/whitesmith/WSTagsField.git",
   "https://github.com/wibosco/GhostTypewriter.git",
   "https://github.com/wickwirew/Runtime.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [W3WSwiftApi](https://github.com/what3words/w3w-swift-wrapper)
* [W3WSwiftComponents](https://github.com/what3words/w3w-swift-components)

## Checklist

I have either:

* [ X] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
