### PR TITLE
Add SwiftMarkdownBuilder

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1037,6 +1037,7 @@
   "https://github.com/DoccZz/docc2html.git",
   "https://github.com/DoccZz/DocCArchive.git",
   "https://github.com/DoccZz/servedocc.git",
+  "https://github.com/DoccZz/SwiftMarkdownBuilder.git",
   "https://github.com/docopt/docopt.swift.git",
   "https://github.com/dokun1/openwhisk-swift-sdk.git",
   "https://github.com/dokun1/vaux.git",


### PR DESCRIPTION
resultBuilders for swift-markdown.

The package(s) being submitted are:

* [SwiftMarkdownBuilder](https://github.com/DoccZz/SwiftMarkdownBuilder/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
