### PR TITLE
Add `xsys`

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2610,6 +2610,7 @@
   "https://github.com/NozeIO/swift-nio-irc-server.git",
   "https://github.com/NozeIO/swift-nio-irc-webclient.git",
   "https://github.com/NozeIO/swift-nio-redis-client.git",
+  "https://github.com/NozeIO/xsys.git",
   "https://github.com/nrkno/yr-cachyr.git",
   "https://github.com/nsagora/bundle-info-versioning.git",
   "https://github.com/nsagora/peppermint.git",


### PR DESCRIPTION
Upon popular request, pulling `xsys` out of Macro/Noze.io
into an own package.

The package(s) being submitted are:

* [xsys](https://github.com/NozeIO/xsys/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
