### PR TITLE
Added pridees/combine-validate

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2921,6 +2921,7 @@
   "https://github.com/postmates/PMJSON.git",
   "https://github.com/poulpix/PXGoogleDirections.git",
   "https://github.com/powerje/telnetkit.git",
+  "https://github.com/pridees/combine-validate.git",
   "https://github.com/priore/SOAPEngine.git",
   "https://github.com/prisma-ai/Sworm.git",
   "https://github.com/priteshrnandgaonkar/atlas.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [CombineValidate](https://github.com/pridees/combine-validate)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

```bash
Processing package list ...
+ https://github.com/pridees/combine-validate.git
✅ validation succeeded
```

and, for sure, I checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
