### PR TITLE
add ASN1Parser package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1074,6 +1074,7 @@
   "https://github.com/dominicegginton/Nanoseconds.git",
   "https://github.com/dominicegginton/spinner.git",
   "https://github.com/DominicHolmes/UIRotationEffect.git",
+  "https://github.com/DominikHorn/ASN1Parser.git",
   "https://github.com/douglashill/DynamicButtonStack.git",
   "https://github.com/douglashill/KeyboardKit.git",
   "https://github.com/dougzilla32/CancelForPromiseKit.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [ASN1Parser](https://github.com/DominikHorn/ASN1Parser)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
