### PR TITLE
adds https://github.com/swift-calendar/icalendarkit.git

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3540,6 +3540,7 @@
   "https://github.com/SwifQL/SwifQL.git",
   "https://github.com/SwifQL/VaporBridges.git",
   "https://github.com/SwifQL/VaporFluentDriver.git",
+  "https://github.com/swift-calendar/icalendarkit.git",
   "https://github.com/swift-extras/swift-extras-base64.git",
   "https://github.com/swift-extras/swift-extras-json.git",
   "https://github.com/swift-server/async-http-client.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [iCalendarKit for Swift](https://github.com/swift-calendar/icalendarkit.git)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
