### PR TITLE
Added new BCrypt library to packages list.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3669,6 +3669,7 @@
   "https://github.com/tannerdsilva/Cepoll.git",
   "https://github.com/tannerdsilva/CLMDB.git",
   "https://github.com/tannerdsilva/RapidLMDB.git",
+  "https://github.com/tannerdsilva/SwiftBCrypt.git",
   "https://github.com/tannerdsilva/SwiftSlash.git",
   "https://github.com/Tantalum73/Audiograph.git",
   "https://github.com/TantePata/SimpleCoreData.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftBcrypt](https://github.com/tannerdsilva/swiftbcrypt)

## Checklist

I have either:

* [✅] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
