### PR TITLE
add MOCloner

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1277,6 +1277,7 @@
   "https://github.com/fassko/TartuWeatherProvider.git",
   "https://github.com/fastlane/fastlane.git",
   "https://github.com/fastred/DeallocationChecker.git",
+  "https://github.com/fatbobman/MOCloner.git",
   "https://github.com/fauna/faunadb-swift.git",
   "https://github.com/favret/poutoupush.git",
   "https://github.com/fborges/environmentalism.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [MOCloner](https://github.com/fatbobman/MOCloner.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
