### PR TITLE
Add PackAPrefPane

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3967,6 +3967,7 @@
   "https://github.com/vtourraine/thirdpartymailer.git",
   "https://github.com/vyshane/grpc-swift-combine.git",
   "https://github.com/vzsg/curly.git",
+  "https://github.com/W1W1-M/PackAPrefPane.git",
   "https://github.com/wacumov/WordNetDecoder.git",
   "https://github.com/watson-developer-cloud/restkit.git",
   "https://github.com/watson-developer-cloud/swift-sdk.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [PackAPrefPane](https://github.com/W1W1-M/PackAPrefPane)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
