### PR TITLE
Added swift-math-parser

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -563,6 +563,7 @@
   "https://github.com/bradhowes/Knob.git",
   "https://github.com/bradhowes/morkandmidi.git",
   "https://github.com/bradhowes/PriorityQueue.git",
+  "https://github.com/bradhowes/swift-math-parser.git",
   "https://github.com/bradlarson/gpuimage2.git",
   "https://github.com/brainfinance/stackdriverlogging.git",
   "https://github.com/braintree/braintree-ios-drop-in.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://github.com/bradhowes/swift-math-parser/)

## Checklist

I have either:

* [X ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
