### PR TITLE
Add InputStepper

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2265,6 +2265,7 @@
   "https://github.com/marty-suzuki/Ricemill.git",
   "https://github.com/marty-suzuki/SABlurImageView.git",
   "https://github.com/MastodonKit/MastodonKit.git",
+  "https://github.com/mateusz800/InputStepper.git",
   "https://github.com/matis-schotte/PublishedKVO.git",
   "https://github.com/matis-schotte/TracingActivity.git",
   "https://github.com/matrejek/SwiftEntitlements.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [InputStepper](https://github.com/mateusz800/InputStepper)

## Checklist

I have either:

* [x ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
