### PR TITLE
Package Blurit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3998,6 +3998,7 @@
   "https://github.com/vzsg/curly.git",
   "https://github.com/W1W1-M/PackAPrefPane.git",
   "https://github.com/wacumov/WordNetDecoder.git",
+  "https://github.com/wassafr/Blurit-ios.git",
   "https://github.com/watson-developer-cloud/restkit.git",
   "https://github.com/watson-developer-cloud/swift-sdk.git",
   "https://github.com/way-to-code/git-macos.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Blurit](https://github.com/wassafr/Blurit-ios.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
