### PR TITLE
Add SwiftCharts

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1699,6 +1699,7 @@
   "https://github.com/istvan-kreisz/CombineReachability.git",
   "https://github.com/ITzTravelInTime/SwiftCPUDetect.git",
   "https://github.com/ivanlisovyi/Dep.git",
+  "https://github.com/ivanschuetz/SwiftCharts.git",
   "https://github.com/ivanvorobei/SPAlert.git",
   "https://github.com/ivanvorobei/SparrowKit.git",
   "https://github.com/ivanvorobei/SPConfetti.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftCharts](https://github.com/ivanschuetz/SwiftCharts)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
