### PR TITLE
Add swift-distributed-actors

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -275,6 +275,7 @@
   "https://github.com/apple/swift-collections.git",
   "https://github.com/apple/swift-corelibs-xctest.git",
   "https://github.com/apple/swift-crypto.git",
+  "https://github.com/apple/swift-distributed-actors/",
   "https://github.com/apple/swift-distributed-tracing-baggage-core.git",
   "https://github.com/apple/swift-distributed-tracing-baggage.git",
   "https://github.com/apple/swift-distributed-tracing.git",


### PR DESCRIPTION
It's a 5.6 package so it won't validate but should we add it anyway?