### PR TITLE
Add APIKeyMiddleware.git

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2989,6 +2989,7 @@
   "https://github.com/pspdfkit/pspdfkitocr-sp.git",
   "https://github.com/psturm-swift/publisher-factory.git",
   "https://github.com/ptrkstr/ACDD-Swift.git",
+  "https://github.com/ptrkstr/APIKeyMiddleware.git",
   "https://github.com/ptrkstr/Devices.git",
   "https://github.com/ptrkstr/Frames.git",
   "https://github.com/ptrkstr/MarkdownChildrenKit.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [APIKeyMiddleware](https://github.com/ptrkstr/apikeymiddleware)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`. (removed swift distributed actors, ran validate, then re-added swift distributed actors)

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
