### PR TITLE
Remove apple/swift-distributed-actors.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -275,7 +275,6 @@
   "https://github.com/apple/swift-collections.git",
   "https://github.com/apple/swift-corelibs-xctest.git",
   "https://github.com/apple/swift-crypto.git",
-  "https://github.com/apple/swift-distributed-actors/",
   "https://github.com/apple/swift-distributed-tracing-baggage-core.git",
   "https://github.com/apple/swift-distributed-tracing-baggage.git",
   "https://github.com/apple/swift-distributed-tracing.git",


### PR DESCRIPTION
This is causing too many problems so I think we should remove it until the validate script can cope. Lack of a validation script is also causing people to be unable to take advantage of our auto-sorting, meaning more manual work on every PR.

It can come back when we support it properly.