### PR TITLE
adding in swift implementation of MurmurHash

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -873,6 +873,7 @@
   "https://github.com/dagronf/DSFVersion.git",
   "https://github.com/dagronf/QRCode.git",
   "https://github.com/dagronf/VIViewInvalidating.git",
+  "https://github.com/daisuke-t-jp/MurmurHash-Swift.git",
   "https://github.com/daltonclaybrook/apispec.git",
   "https://github.com/daltoniam/Starscream.git",
   "https://github.com/damuellen/Gnuplot.swift.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [MurmurHash_Swift](https://github.com/daisuke-t-jp/MurmurHash-Swift.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
