### PR TITLE
Swift 5.5/5.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ on:
     branches: [ main ]
 
 env:
-  SWIFT_IMAGE: swiftlang/swift@sha256:a0d75888a49938175bb4da3a3d6e3ab5cdf3095fe71ed427ee4a03a05a78336d  # swift 5.5 nightly
+  # Swift version 5.6-dev (LLVM 542eceb110d8480, Swift 4323d2fa26a6bf8)
+  # Target: x86_64-unknown-linux-gnu
+  SWIFT_IMAGE: swiftlang/swift@sha256:cc3a796de27ef460b7b4a3dc8f2e7e5aff7fcae989ea49674753a87261ae0448
 
 jobs:
   validate:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
 
     - name: Run checks
       env:
-        DEVELOPER_DIR: /Applications/Xcode_12.5.app
+        DEVELOPER_DIR: /Applications/Xcode_13.1.app
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         rm -f ./validator

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run_nightly:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run_nightly:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -15,7 +15,7 @@ jobs:
     - name: Run checks
       env:
         # see https://github.com/actions/virtual-environments for supported Xcode versions
-        DEVELOPER_DIR: /Applications/Xcode_13.2.app
+        DEVELOPER_DIR: /Applications/Xcode_13.1.app
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         rm -f ./validator

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,8 @@ jobs:
 
     - name: Run checks
       env:
-        DEVELOPER_DIR: /Applications/Xcode_13.1.app
+        # see https://github.com/actions/virtual-environments for supported Xcode versions
+        DEVELOPER_DIR: /Applications/Xcode_13.2.app
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         rm -f ./validator

--- a/packages.json
+++ b/packages.json
@@ -275,6 +275,7 @@
   "https://github.com/apple/swift-collections.git",
   "https://github.com/apple/swift-corelibs-xctest.git",
   "https://github.com/apple/swift-crypto.git",
+  "https://github.com/apple/swift-distributed-actors.git",
   "https://github.com/apple/swift-distributed-tracing-baggage-core.git",
   "https://github.com/apple/swift-distributed-tracing-baggage.git",
   "https://github.com/apple/swift-distributed-tracing.git",


### PR DESCRIPTION
Fixes https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1436

~We cannot set 5.6 support for the nightly validator at this time because there's no Xcode beta with 5.6 available on Github right now (I believe) and it's not quite so simple to install a custom toolchain on a runner.~

~This should be fine - we're actually still running with the nightly supporting only 5.4 at the moment. All it does is not re-validate 5.5 (and then 5.6) packages.~

There's an [Xcode 13.2 listed](https://github.com/actions/virtual-environments) in the installed apps, giving that a try. (We'll only see the results after merge and the first nightly run though.)

Actually, that comment about 5.6 above still stands. Xcode 13.2 is Swift 5.5.2. We'd need to install an actual nightly toolchain to get 5.6 for the nightly.