### PR TITLE
Added Onfido SDK and Onfido Auth SDK into the packages list

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2754,6 +2754,8 @@
   "https://github.com/onevcat/Kingfisher.git",
   "https://github.com/onevcat/Rainbow.git",
   "https://github.com/onevcat/RandomColorSwift.git",
+  "https://github.com/onfido/onfido-auth-sdk-ios.git",
+  "https://github.com/onfido/onfido-ios-sdk.git",
   "https://github.com/onmyway133/EasyConfetti.git",
   "https://github.com/onmyway133/Smile.git",
   "https://github.com/onmyway133/Spek.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
