### PR TITLE
Add WebURL

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1917,6 +1917,7 @@
   "https://github.com/KarthikRIyer/swiftplot.git",
   "https://github.com/karthironald/KSTimerView.git",
   "https://github.com/karwa/swift-checkit.git",
+  "https://github.com/karwa/swift-url.git",
   "https://github.com/kasei/diomede.git",
   "https://github.com/kasei/IDPPlanner.git",
   "https://github.com/kasei/kineo-endpoint.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [WebURL](https://github.com/karwa/swift-url)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
