### PR TITLE
Add A11yoop

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1723,6 +1723,7 @@
   "https://github.com/iZettle/Flow.git",
   "https://github.com/iZettle/Lift.git",
   "https://github.com/j-f1/MenuBuilder.git",
+  "https://github.com/Jackstone92/A11yoop.git",
   "https://github.com/Jackstone92/CombineRx.git",
   "https://github.com/jacopomangiavacchi/swiftnormalization.git",
   "https://github.com/jacopomangiavacchi/thrift-swift-nio.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [A11yoop](https://github.com/Jackstone92/A11yoop)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
