### PR TITLE
Add RxCombine

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -756,6 +756,7 @@
   "https://github.com/CombineCommunity/CombinePrintout.git",
   "https://github.com/CombineCommunity/CombineRealm.git",
   "https://github.com/CombineCommunity/Feedbacks.git",
+  "https://github.com/CombineCommunity/RxCombine.git",
   "https://github.com/CombineHarvesters/AVFoundationCombine.git",
   "https://github.com/CombineHarvesters/CombineTesting.git",
   "https://github.com/CombineHarvesters/FoundationCombine.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [RxCombine](https://github.com/CombineCommunity/RxCombine)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
