### PR TITLE
Update packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3102,6 +3102,7 @@
   "https://github.com/readdle/swift-java-coder.git",
   "https://github.com/readdle/swift-java.git",
   "https://github.com/readeval/contentsecuritypolicy.git",
+  "https://github.com/real-intelligence/Clarity.git",
   "https://github.com/realm/realm-core.git",
   "https://github.com/realm/realm-swift.git",
   "https://github.com/realm/SwiftLint.git",


### PR DESCRIPTION
Added real-intelligence Clarity Swift package to the index

The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
