### PR TITLE
Add AsyncCloudKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -693,6 +693,7 @@
   "https://github.com/chiragramani/Tron.git",
   "https://github.com/chojnac/Dumpling.git",
   "https://github.com/chojnac/NotionSwift.git",
+  "https://github.com/chris-araman/AsyncCloudKit.git",
   "https://github.com/chris-araman/CombineCloudKit.git",
   "https://github.com/chrisaljoudi/swift-log-oslog.git",
   "https://github.com/chrisamanse/QRSwift.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [AsyncCloudKit](https://github.com/chris-araman/AsyncCloudKit/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
