### PR TITLE
Added TroposAR SDK

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3865,6 +3865,7 @@
   "https://github.com/trilemma-dev/EmbeddedPropertyList.git",
   "https://github.com/trilemma-dev/SecureXPC.git",
   "https://github.com/tristanhimmelman/ObjectMapper.git",
+  "https://github.com/Tropos-AR/tropos-sdk-ios-spm.git",
   "https://github.com/trsathya/cryptex.git",
   "https://github.com/truizlop/FuzzyFind.git",
   "https://github.com/trusk89/bartisutilities.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [TroposAR](  https://github.com/Tropos-AR/tropos-sdk-ios-spm.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
