### PR TITLE
Added BitWiser

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1114,6 +1114,7 @@
   "https://github.com/dparnell/swift-parser-generator.git",
   "https://github.com/dpedley/swift-chess.git",
   "https://github.com/dral3x/stringslint.git",
+  "https://github.com/DrAma999/BitWiser.git",
   "https://github.com/DrAma999/LittleBlueTooth.git",
   "https://github.com/drewag/Decree.git",
   "https://github.com/drewag/DecreeServices.git",


### PR DESCRIPTION
Added BitWiser to packages.json

The package(s) being submitted are:

* [Bitwiser](https://github.com/DrAma999/BitWiser.git)

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [X] The package repositories are publicly accessible.
* [X] The packages all contain a `Package.swift` file in the root folder.
* [X] The packages are written in Swift 5.0 or later.
* [X] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [X] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [X] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [X] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [X] The packages all compile without errors.
* [X] The package list JSON file is sorted alphabetically.
