### PR TITLE
Added NativeMarkKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -233,6 +233,7 @@
   "https://github.com/andtie/SequenceBuilder.git",
   "https://github.com/andtie/YukonMatchedGeometry.git",
   "https://github.com/andybest/linenoise-swift.git",
+  "https://github.com/andyfinnell/NativeMarkKit.git",
   "https://github.com/andymedvedev/CTXTutorialEngine.git",
   "https://github.com/angelopino/APJExtensions.git",
   "https://github.com/aniket965/argstodict.git",


### PR DESCRIPTION
Added NativeMarkKit to packages.json

The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
