### PR TITLE
FelixHerrmann/swift-multipart-formdata added

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1320,6 +1320,7 @@
   "https://github.com/FelixHerrmann/FHExtensions.git",
   "https://github.com/FelixHerrmann/FHPropertyWrappers.git",
   "https://github.com/FelixHerrmann/intercom-ios.git",
+  "https://github.com/FelixHerrmann/swift-multipart-formdata.git",
   "https://github.com/FelixHerrmann/swift-package-list.git",
   "https://github.com/fermoya/SwiftUIPager.git",
   "https://github.com/fernandodelrio/swiftcolorgenlibrary.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [swift-multipart-formdata](https://github.com/FelixHerrmann/swift-multipart-formdata)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
