### PR TITLE
Added Snappable

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1641,6 +1641,7 @@
   "https://github.com/honghaoz/Ji.git",
   "https://github.com/hootsuite/emit.git",
   "https://github.com/httpswift/swifter.git",
+  "https://github.com/hugehoge/Snappable.git",
   "https://github.com/hummingbird-project/hummingbird-auth.git",
   "https://github.com/hummingbird-project/hummingbird-compression.git",
   "https://github.com/hummingbird-project/hummingbird-core.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Snappable](https://github.com/hugehoge/Snappable)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
