### PR TITLE
Added SchafKit and SwiftyOpenGraph

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3084,7 +3084,9 @@
   "https://github.com/quickbirdstudios/XServiceLocator.git",
   "https://github.com/quickthyme/qloop.git",
   "https://github.com/quickthyme/qroute.git",
-  "https://github.com/quickthyme/webrequest.git",
+  "https://github.com/quickthyme/webrequest.git",,
+  "https://github.com/Quintschaf/SchafKit.git",
+  "https://github.com/Quintschaf/SwiftyOpenGraph.git"
   "https://github.com/quver/SlidableImage.git",
   "https://github.com/quynhnguyen/slidingtabview.git",
   "https://github.com/r-dent/EliminationMenu.git",
@@ -4233,7 +4235,5 @@
   "https://github.com/zummenix/KeyboardNotificationsObserver.git",
   "https://github.com/zvonicek/ImageSlideshow.git",
   "https://github.com/zweigraf/fakebundle.git",
-  "https://github.com/zxcj04/WMSKit.git",
-  "https://github.com/Quintschaf/SchafKit.git",
-  "https://github.com/Quintschaf/SwiftyOpenGraph.git"
+  "https://github.com/zxcj04/WMSKit.git"
 ]

--- a/packages.json
+++ b/packages.json
@@ -3084,9 +3084,9 @@
   "https://github.com/quickbirdstudios/XServiceLocator.git",
   "https://github.com/quickthyme/qloop.git",
   "https://github.com/quickthyme/qroute.git",
-  "https://github.com/quickthyme/webrequest.git",,
+  "https://github.com/quickthyme/webrequest.git",
   "https://github.com/Quintschaf/SchafKit.git",
-  "https://github.com/Quintschaf/SwiftyOpenGraph.git"
+  "https://github.com/Quintschaf/SwiftyOpenGraph.git",
   "https://github.com/quver/SlidableImage.git",
   "https://github.com/quynhnguyen/slidingtabview.git",
   "https://github.com/r-dent/EliminationMenu.git",

--- a/packages.json
+++ b/packages.json
@@ -4233,5 +4233,7 @@
   "https://github.com/zummenix/KeyboardNotificationsObserver.git",
   "https://github.com/zvonicek/ImageSlideshow.git",
   "https://github.com/zweigraf/fakebundle.git",
-  "https://github.com/zxcj04/WMSKit.git"
+  "https://github.com/zxcj04/WMSKit.git",
+  "https://github.com/Quintschaf/SchafKit.git",
+  "https://github.com/Quintschaf/SwiftyOpenGraph.git"
 ]


### PR DESCRIPTION
The package(s) being submitted are:

* [SchafKit](https://github.com/Quintschaf/SchafKit)
* [SwiftyOpenGraph](https://github.com/Quintschaf/SwiftyOpenGraph)

## Checklist

I have checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
