### PR TITLE
Remove unavailable package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -44,7 +44,6 @@
   "https://github.com/AaronBratcher/AgileDB.git",
   "https://github.com/aaronsky/buildkite-swift.git",
   "https://github.com/abadikaka/SFSymbolsFinder.git",
-  "https://github.com/abdalaliii/CoreDataUtils.git",
   "https://github.com/abdalaliii/ReplayLatest.git",
   "https://github.com/abdalaliii/RetryOn.git",
   "https://github.com/abdalaliii/Unboxing.git",


### PR DESCRIPTION
The package(s) being removed is:

* [CoreDataUtils](https://github.com/abdalaliii/CoreDataUtils.git/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories is not publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
