### PR TITLE
add package flopshot/Navigator

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1385,6 +1385,7 @@
   "https://github.com/flintprocessor/Motor.git",
   "https://github.com/flintprocessor/Work.git",
   "https://github.com/flipside5/sos.git",
+  "https://github.com/flopshot/Navigator.git",
   "https://github.com/florianreinhart/geodesy.git",
   "https://github.com/flowbe/MaterialOutlinedTextField.git",
   "https://github.com/flowtoolz/SwiftObserver.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Navigator](https://github.com/flopshot/Navigator.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
