### PR TITLE
Add packages from github.com/darrarski

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -952,6 +952,8 @@
   "https://github.com/darrarski/swift-composable-presentation.git",
   "https://github.com/darrarski/SwiftEndpoint.git",
   "https://github.com/darrarski/swiftui-app-icon-creator.git",
+  "https://github.com/darrarski/swiftui-tabs-view.git",
+  "https://github.com/darrarski/SwiftUIMKMapView.git",
   "https://github.com/darrarski/xcframework-maker.git",
   "https://github.com/DarthStrom/Moxie.git",
   "https://github.com/dasautoooo/Parma.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [swiftui-tabs-view](https://github.com/darrarski/swiftui-tabs-view.git)
* [SwiftUIMKMapView](https://github.com/darrarski/SwiftUIMKMapView.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
