### PR TITLE
add swift-log-sentry

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1275,6 +1275,7 @@
   "https://github.com/ericlewis/ActivityIndicatorView.git",
   "https://github.com/ericlewis/BlurView.git",
   "https://github.com/ericlewis/ProgressView.git",
+  "https://github.com/ericlewis/swift-log-sentry.git",
   "https://github.com/ericlewis/THOTP.git",
   "https://github.com/ericlewis/URL-QueryItem.git",
   "https://github.com/ericlewis/Valet-THOTP.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [swift-log-sentry](https://github.com/ericlewis/swift-log-sentry)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
