### PR TITLE
Add SimpleTipJar

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -670,6 +670,7 @@
   "https://github.com/CharlesJS/CSErrors.git",
   "https://github.com/CharlesJS/CSProgress.git",
   "https://github.com/CharlesJS/SwiftyXPC.git",
+  "https://github.com/chaseacton/SimpleTipJar.git",
   "https://github.com/che1404/vipergen.git",
   "https://github.com/checkout/checkout-event-logger-ios-framework.git",
   "https://github.com/checkout/frames-ios.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SimpleTipJar](https://github.com/chaseacton/SimpleTipJar)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
