### PR TITLE
Addedd SwiftFinancial to package list

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4286,6 +4286,7 @@
   "https://github.com/zonble/turtlebuilder.git",
   "https://github.com/zonble/ZBSimplePluginManager.git",
   "https://github.com/zoul/generic-json-swift.git",
+  "https://github.com/zrluety/SwiftFinancial.git",
   "https://github.com/zssz/BerkananCompression.git",
   "https://github.com/zssz/BerkananFoundation.git",
   "https://github.com/zssz/BerkananSDK.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftFinancial](https://github.com/zrluety/SwiftFinancial)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
