### PR TITLE
add swifty-inapp-messaging

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1452,6 +1452,7 @@
   "https://github.com/fulldecent/FDTake.git",
   "https://github.com/fulldecent/FDTextFieldTableViewCell.git",
   "https://github.com/fulldecent/FDWaveformView.git",
+  "https://github.com/fumito-ito/SwiftyInAppMessaging.git",
   "https://github.com/fumito-ito/SwiftyRemoteConfig.git",
   "https://github.com/fummicc1/EasyFirebaseSwift.git",
   "https://github.com/fummicc1/SimpleRoulette.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftyInAppMessaging](https://github.com/fumito-ito/SwiftyInAppMessaging)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
