### PR TITLE
Added OpenConnectivity

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3328,6 +3328,7 @@
   "https://github.com/rwbutler/ipauploader.git",
   "https://github.com/rwbutler/LetterCase.git",
   "https://github.com/rwbutler/QSH.git",
+  "https://github.com/rwbutler/OpenConnectivity.git",
   "https://github.com/rwbutler/swift-quiz.git",
   "https://github.com/rwbutler/TypographyKit.git",
   "https://github.com/rwbutler/typographykitpalette.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [OpenConnectivity](https://github.com/rwbutler/OpenConnectivity)

This is a package that will allow users to track state changes in Internet connectivity using OpenCombine in situations where Apple's Combine may be unavailable e.g. pre-iOS 13.

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
