### PR TITLE
Add SubVT Data Swift package.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1642,6 +1642,7 @@
   "https://github.com/heestand-xyz/AirKit.git",
   "https://github.com/heestand-xyz/PolyKit.git",
   "https://github.com/heestand-xyz/Trails.git",
+  "https://github.com/helikon-labs/subvt-data-swift.git",
   "https://github.com/helje5/Highlightr.git",
   "https://github.com/hendriku/colorpicker.git",
   "https://github.com/HeroTransitions/Hero.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SubVT Data Swift](https://github.com/helikon-labs/subvt-data-swift)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
