### PR TITLE
Add `composable-effect-identifier`

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3856,6 +3856,7 @@
   "https://github.com/terwanerik/httpcodable.git",
   "https://github.com/tevelee/Eval.git",
   "https://github.com/tevelee/Tuxedo.git",
+  "https://github.com/tgrapperon/composable-effect-identifier.git",
   "https://github.com/tgrapperon/swift-composable-environment.git",
   "https://github.com/tgu/rosswift.git",
   "https://github.com/tgymnich/ClosurePublisher.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [composable-effect-identifier](https://github.com/tgrapperon/composable-effect-identifier/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
