### PR TITLE
Added Immobiliare.it packages: RealHTTP and RealFlags

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1745,6 +1745,8 @@
   "https://github.com/imgly/imglykit-sp.git",
   "https://github.com/imgly/pesdk-ios-build.git",
   "https://github.com/imgly/vesdk-ios-build.git",
+  "https://github.com/immobiliare/RealFlags.git",
+  "https://github.com/immobiliare/RealHTTP.git",
   "https://github.com/inamiy/FunOptics.git",
   "https://github.com/inamiy/RxAutomaton.git",
   "https://github.com/inamiy/rxproperty.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
