### PR TITLE
Add package WHPlayingCardImageKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4316,5 +4316,6 @@
   "https://github.com/zummenix/KeyboardNotificationsObserver.git",
   "https://github.com/zvonicek/ImageSlideshow.git",
   "https://github.com/zweigraf/fakebundle.git",
-  "https://github.com/zxcj04/WMSKit.git"
+  "https://github.com/zxcj04/WMSKit.git",
+  "https://github.com/billh0420/WHPlayingCardImageKit.git"
 ]

--- a/packages.json
+++ b/packages.json
@@ -514,6 +514,7 @@
   "https://github.com/bigMOTOR/DataDrivenRxDatasources.git",
   "https://github.com/bigMOTOR/swift-lens.git",
   "https://github.com/bignerdranch/Deferred.git",
+  "https://github.com/billh0420/WHPlayingCardImageKit.git",
   "https://github.com/Bilue/ContentFittingWebView.git",
   "https://github.com/BinaryBirds/build-kit.git",
   "https://github.com/BinaryBirds/git-kit.git",

--- a/packages.json
+++ b/packages.json
@@ -4316,6 +4316,5 @@
   "https://github.com/zummenix/KeyboardNotificationsObserver.git",
   "https://github.com/zvonicek/ImageSlideshow.git",
   "https://github.com/zweigraf/fakebundle.git",
-  "https://github.com/zxcj04/WMSKit.git",
-  "https://github.com/billh0420/WHPlayingCardImageKit.git"
+  "https://github.com/zxcj04/WMSKit.git"
 ]


### PR DESCRIPTION
The package(s) being submitted are:

* [WHPlayingCardImageKit](https://github.com/billh0420/WHPlayingCardImageKit.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
