### PR TITLE
Added AUv3Support package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -574,6 +574,7 @@
   "https://github.com/bppr/speck.git",
   "https://github.com/bradhowes/ArrowView.git",
   "https://github.com/bradhowes/astar.git",
+  "https://github.com/bradhowes/AUv3Support.git",
   "https://github.com/bradhowes/Checkbox.git",
   "https://github.com/bradhowes/DottedVersionVector.git",
   "https://github.com/bradhowes/Joystick.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [AUv3Support](https://github.com/bradhowes/AUv3Support)

## Checklist

I have either:

* [x ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
