### PR TITLE
add persistent history tracking kit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1342,6 +1342,7 @@
   "https://github.com/fastlane/fastlane.git",
   "https://github.com/fastred/DeallocationChecker.git",
   "https://github.com/fatbobman/MOCloner.git",
+  "https://github.com/fatbobman/PersistentHistoryTrackingKit.git",
   "https://github.com/fatbobman/SheetKit.git",
   "https://github.com/fauna/faunadb-swift.git",
   "https://github.com/favret/poutoupush.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [*] Run `swift ./validate.swift`.

Or, checked that:

* [* ] The package repositories are publicly accessible.
* [ *] The packages all contain a `Package.swift` file in the root folder.
* [ *] The packages are written in Swift 5.0 or later.
* [ *] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ *] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ *] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ *] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ *] The packages all compile without errors.
* [ *] The package list JSON file is sorted alphabetically.
