### PR TITLE
Add SwiftyPSCore

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1141,6 +1141,7 @@
   "https://github.com/DominikHorn/ASN1Parser.git",
   "https://github.com/douglashill/DynamicButtonStack.git",
   "https://github.com/douglashill/KeyboardKit.git",
+  "https://github.com/dougonecent/SwiftyPSCore.git",
   "https://github.com/dougzilla32/CancelForPromiseKit.git",
   "https://github.com/dparnell/swift-parser-generator.git",
   "https://github.com/dpedley/swift-chess.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftyPSCore](https://github.com/dougonecent/SwiftyPSCore)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
