### PR TITLE
Add GitHub Issues form to automatically add a Swift Package to the index

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_package.yml
+++ b/.github/ISSUE_TEMPLATE/add_package.yml
@@ -1,0 +1,30 @@
+name: Add Package(s)
+description: Add one or more new packages to the Swift Package Index.
+title: "Add Package"
+labels: ["add_package"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to contribute to Swift Package Index.
+
+        There's no gatekeeping or quality threshold to be included in the Swift Package Index. As long as packages are valid, and meet the requirements below, we will accept them. If you're unsure, submit the package and we can provide any necessary feedback.
+
+        * The package repositories are all publicly accessible.
+        * The packages all contain a Package.swift file in the root folder.
+        * The packages are written in Swift 5.0 or later.
+        * The packages all contain at least one product (either library or executable), and at least one product must be usable in other Swift apps.
+        * The packages all have at least one release tagged as a [semantic version](https://semver.org/).
+        * The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
+        * The package URLs are all fully specified including the protocol (usually https) and the `.git` extension.
+        * The packages all compile without errors.
+  - type: textarea
+    id: list
+    attributes:
+      label: List Packages
+      description: Please list all of the packages you wish to add here. Place each package on a new line.
+      placeholder: |
+        https://github.com/daveverwer/LeftPad
+        https://github.com/Sherlouk/swift-snapshot-testing-stitch
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Add a Package
-    url: https://swiftpackageindex.com/add-a-package
-    about: Add one or more new packages to the Swift Package Index
   - name: Bugs and Feature Requests
     url: https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/new/choose
     about: Do you have a bug or feature request related to the Swift Package Index?

--- a/.github/add_package.sh
+++ b/.github/add_package.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+if [[ -z "${GH_BODY}" ]]; then
+    echo "::error::Missing GH_BODY environment variable."
+    exit 1
+fi
+
+# 0. Take Backup for Comparison
+
+cp packages.json packages-backup.json
+
+# 1. Cycle over Lines
+
+echo "${GH_BODY}" | while read url ; do
+    url=$(echo "$url" | sed 's/\r//g')
+    echo "Processing '$url'."
+
+    # 1a. Skip non URLs
+    if [[ $url != https://github.com/* ]]; then
+        continue
+    fi
+
+    # 1b. Normalise URL
+    if [[ $url != *.git ]]; then
+        # Add `.git` at end
+        url="$url.git"
+    fi
+
+    # 1c. Append Item
+    jq '. |= . + ["'$url'"]' -S packages.json > temp.json
+
+    # 1d. Remove Duplicates and Sort
+    jq '.|unique' temp.json > packages.json
+    rm temp.json 
+done
+
+# 2. Compare
+
+diff --brief packages.json packages-backup.json >/dev/null
+CONTAINS_CHANGES=$?
+
+if [ $CONTAINS_CHANGES -eq 1 ]; then
+    echo '::set-output name=changes::true'
+else
+    echo '::set-output name=changes::false'
+fi

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,77 @@
+name: Automatic Pull Request
+
+on:
+  issues:
+    types: [ opened ]
+
+env:
+  # Swift version 5.6-dev (LLVM 542eceb110d8480, Swift 4323d2fa26a6bf8)
+  # Target: x86_64-unknown-linux-gnu
+  SWIFT_IMAGE: swiftlang/swift@sha256:cc3a796de27ef460b7b4a3dc8f2e7e5aff7fcae989ea49674753a87261ae0448
+
+jobs:
+  add:
+    runs-on: ubuntu-20.04
+    if: contains(github.event.issue.labels.*.name, 'add_package')
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Add Package to JSON
+      run: bash .github/add_package.sh
+      id: package
+      env:
+        GH_BODY: ${{ github.event.issue.body }}
+
+    - name: Validate JSON
+      if: steps.package.outputs.changes == 'true'
+      run: docker run --rm -v "$PWD:/host" -w /host $SWIFT_IMAGE swift validate.swift
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create Pull Request
+      id: cpr
+      if: steps.package.outputs.changes == 'true'
+      uses: peter-evans/create-pull-request@v3
+      with:
+        add-paths: |
+          packages.json
+        commit-message: ${{ github.event.issue.title }}
+        title: ${{ github.event.issue.title }}
+        branch: spi-auto-${{ github.event.issue.number }}
+        delete-branch: true
+        body: |
+          Closes #${{ github.event.issue.number }}
+
+          ## Original Message
+
+          ${{ github.event.issue.body }}
+        committer: ${{ github.event.issue.user.login }} <${{ github.event.issue.user.login }}@users.noreply.github.com>
+        author: ${{ github.event.issue.user.login }} <${{ github.event.issue.user.login }}@users.noreply.github.com>
+
+    - name: Update Issue (Success)
+      if: steps.package.outputs.changes == 'true'
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'Congrats! A pull request has been successfully created: #${{ steps.cpr.outputs.pull-request-number }}. We hope to merge this for you shortly.'
+          })
+
+    - name: Update Issue (Failure)
+      if: steps.package.outputs.changes != 'true'
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'Oh no! Unfortunately we were unable to detect any new packages within your comment.'
+          })


### PR DESCRIPTION
## What?

This creates a GitHub Issue Form (https://github.blog/changelog/2021-06-23-issues-forms-beta-for-public-repositories/) which asks users for a list of package URLs. This form will auto-tag the issue with "add_package".

Using GitHub Actions, we then detect this new issue with the tag and automatically extract the URLs and insert them into the `packages.json` array.

We then use GitHub Actions to commit and push these changes to a new pull request, which is then commented on the issue for effect.

Here are some screenshots from a little test I have run (made tiny changes since this which is why it may not match perfectly)

![image](https://user-images.githubusercontent.com/15193942/154146532-10a84891-6b15-4276-8ed3-268e53418b45.png)
![image](https://user-images.githubusercontent.com/15193942/154146551-77b677aa-f42e-4a32-a1aa-deb24ea5a176.png)
![image](https://user-images.githubusercontent.com/15193942/154146564-9e3208d9-0ea8-4854-a189-2786691895bb.png)

## Why?

The hope is that by simplifying the process, we can make it easier for folks to contribute their packages. You no longer need to clone the project, simply raise an issue with a link to the project and everything is handled automatically for you.

## Next Steps

* Merge and test capability end-to-end
* Update documentation
* Replace "add a package" page on SPI.com
* Duplicate form and script for "Remove Package(s)" which can be automated too
* Automatically merge the PR (?)