### PR TITLE
Add QuranEngine

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3164,6 +3164,7 @@
   "https://github.com/quickthyme/webrequest.git",
   "https://github.com/Quintschaf/SchafKit.git",
   "https://github.com/Quintschaf/SwiftyOpenGraph.git",
+  "https://github.com/quran/quran-ios.git",
   "https://github.com/quver/SlidableImage.git",
   "https://github.com/quynhnguyen/slidingtabview.git",
   "https://github.com/r-dent/EliminationMenu.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [QuranEngine](https://github.com/quran/quran-ios)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
