### PR TITLE
AutoPR Tweaks

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_package.yml
+++ b/.github/ISSUE_TEMPLATE/add_package.yml
@@ -1,7 +1,7 @@
 name: Add Package(s)
 description: Add one or more new packages to the Swift Package Index.
-title: "Add Package"
-labels: ["add_package"]
+title: "Add <Package>"
+labels: ["Add Package"]
 body:
   - type: markdown
     attributes:
@@ -23,8 +23,6 @@ body:
     attributes:
       label: List Packages
       description: Please list all of the packages you wish to add here. Place each package on a new line.
-      placeholder: |
-        https://github.com/daveverwer/LeftPad
-        https://github.com/Sherlouk/swift-snapshot-testing-stitch
+      placeholder: https://github.com/daveverwer/LeftPad.git
     validations:
       required: true

--- a/.github/add_package.sh
+++ b/.github/add_package.sh
@@ -13,34 +13,17 @@ cp packages.json packages-backup.json
 
 echo "${GH_BODY}" | while read url ; do
     url=$(echo "$url" | sed 's/\r//g')
-    echo "Processing '$url'."
 
     # 1a. Skip non URLs
     if [[ $url != https://github.com/* ]]; then
         continue
     fi
 
-    # 1b. Normalise URL
-    if [[ $url != *.git ]]; then
-        # Add `.git` at end
-        url="$url.git"
-    fi
-
-    # 1c. Append Item
+    # 1b. Append Item
     jq '. |= . + ["'$url'"]' -S packages.json > temp.json
+    echo "+ '$url'."
 
-    # 1d. Remove Duplicates and Sort
+    # 1c. Remove Duplicates and Sort
     jq '.|unique' temp.json > packages.json
     rm temp.json 
 done
-
-# 2. Compare
-
-diff --brief packages.json packages-backup.json >/dev/null
-CONTAINS_CHANGES=$?
-
-if [ $CONTAINS_CHANGES -eq 1 ]; then
-    echo '::set-output name=changes::true'
-else
-    echo '::set-output name=changes::false'
-fi

--- a/.github/add_package.sh
+++ b/.github/add_package.sh
@@ -21,9 +21,7 @@ echo "${GH_BODY}" | while read url ; do
 
     # 1b. Append Item
     jq '. |= . + ["'$url'"]' -S packages.json > temp.json
+    mv temp.json packages.json
+    rm temp.json
     echo "+ '$url'."
-
-    # 1c. Remove Duplicates and Sort
-    jq '.|unique' temp.json > packages.json
-    rm temp.json 
 done

--- a/.github/check_for_changes.sh
+++ b/.github/check_for_changes.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+diff --brief packages.json packages-backup.json >/dev/null
+CONTAINS_CHANGES=$?
+
+if [ $CONTAINS_CHANGES -eq 1 ]; then
+    echo '::set-output name=changes::true'
+else
+    echo '::set-output name=changes::false'
+fi

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   add:
     runs-on: ubuntu-20.04
-    if: contains(github.event.issue.labels.*.name, 'add_package')
+    if: contains(github.event.issue.labels.*.name, 'Add Package')
 
     steps:
     - name: Checkout
@@ -20,19 +20,21 @@ jobs:
 
     - name: Add Package to JSON
       run: bash .github/add_package.sh
-      id: package
       env:
         GH_BODY: ${{ github.event.issue.body }}
 
     - name: Validate JSON
-      if: steps.package.outputs.changes == 'true'
       run: docker run --rm -v "$PWD:/host" -w /host $SWIFT_IMAGE swift validate.swift
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Check for Changes
+      run: bash .github/check_for_changes.sh
+      id: check
+
     - name: Create Pull Request
       id: cpr
-      if: steps.package.outputs.changes == 'true'
+      if: steps.check.outputs.changes == 'true'
       uses: peter-evans/create-pull-request@v3
       with:
         add-paths: |
@@ -51,7 +53,7 @@ jobs:
         author: ${{ github.event.issue.user.login }} <${{ github.event.issue.user.login }}@users.noreply.github.com>
 
     - name: Update Issue (Success)
-      if: steps.package.outputs.changes == 'true'
+      if: steps.check.outputs.changes == 'true'
       uses: actions/github-script@v3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -64,7 +66,7 @@ jobs:
           })
 
     - name: Update Issue (Failure)
-      if: steps.package.outputs.changes != 'true'
+      if: steps.check.outputs.changes != 'true'
       uses: actions/github-script@v3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -25,6 +25,7 @@ jobs:
 
     - name: Validate JSON
       run: docker run --rm -v "$PWD:/host" -w /host $SWIFT_IMAGE swift validate.swift
+      continue-on-error: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
* Rename issues to make it more likely folks will drop the package name in
* Rename label to be more user-friendly ("Add Package" not "add_package")
* Tweak example placeholder to be fully formatted (add .git) and only one to avoid issue on Safari browsers
* Remove .git addition from the AutoPR script (the validate script should do it for us)
* Detect changes in packages.json after the validate step, allowing us to use the output of the validate script for AutoPR eliminating a lot of duplication and ensuring the validate script is a single source of truth.