### PR TITLE
Add DependencyKit and ScopeKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1568,6 +1568,8 @@
   "https://github.com/gonzalezreal/SimpleNetworking.git",
   "https://github.com/gonzalezreal/SwiftCommonMark.git",
   "https://github.com/gonzalezreal/UnifiedLogging.git",
+  "https://github.com/GoodHatsLLC/DependencyKit.git",
+  "https://github.com/GoodHatsLLC/ScopeKit.git",
   "https://github.com/google/google-api-objectivec-client-for-rest.git",
   "https://github.com/google/GoogleAppMeasurement.git",
   "https://github.com/google/GoogleDataTransport.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [DependencyKit](https://github.com/GoodHatsLLC/DependencyKit)
* [ScopeKit](https://github.com/GoodHatsLLC/ScopeKit)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
