### PR TITLE
Added Swift unit conversion library

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3146,6 +3146,7 @@
   "https://github.com/pusher/push-notifications-swift.git",
   "https://github.com/pusher/pusher-http-swift.git",
   "https://github.com/pusher/pusher-websocket-swift.git",
+  "https://github.com/putridparrot/SwiftUnits.git",
   "https://github.com/pvieito/LoggerKit.git",
   "https://github.com/pvieito/PythonKit.git",
   "https://github.com/pvzig/SKClient.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftUnits](https://github.com/putridparrot/SwiftUnits/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
