### PR TITLE
Run CI on package review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  pull_request_review:
+    types: [submitted]
 
 env:
   # Swift version 5.6-dev (LLVM 542eceb110d8480, Swift 4323d2fa26a6bf8)


### PR DESCRIPTION
This should sort out the CI part until we decide to set up a proper account that can trigger runs.

It should also sort out running the CI after approving the nightly.

The mistake I made previously was set this on the _nightly_ script instead of the _CI_ script. That's why it triggered the nightly on each approval 🤦 