### PR TITLE
Add swift-pocket.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3518,6 +3518,7 @@
   "https://github.com/seznam/swift-uniyaml.git",
   "https://github.com/SFSafeSymbols/SFSafeSymbols.git",
   "https://github.com/sgade/InFlightValue.git",
+  "https://github.com/sgade/swift-pocket.git",
   "https://github.com/sgade/swiftui-mapview.git",
   "https://github.com/sh3l6orrr/swift-music.git",
   "https://github.com/Shadberrow/YVAnchor.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [sgade/swift-pocket](https://github.com/sgade/swift-pocket)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [o] The package repositories are publicly accessible.
* [o] The packages all contain a `Package.swift` file in the root folder.
* [o] The packages are written in Swift 5.0 or later.
* [o] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [o] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [o] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [o] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [o] The packages all compile without errors.
* [o] The package list JSON file is sorted alphabetically.
