### PR TITLE
Added Google Jacquard SDK.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1579,6 +1579,7 @@
   "https://github.com/google/GoogleUtilities.git",
   "https://github.com/google/gtm-session-fetcher.git",
   "https://github.com/google/GTMAppAuth.git",
+  "https://github.com/google/JacquardSDKiOS.git",
   "https://github.com/google/open-location-code-swift.git",
   "https://github.com/google/promises.git",
   "https://github.com/google/swift-benchmark.git",


### PR DESCRIPTION
https://atap.google.com/intl/en_uk/jacquard/
https://atap.google.com/intl/en_uk/jacquard/jacquardsdk/

The package(s) being submitted are:

* [Package Name](https://github.com/google/JacquardSDKiOS)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
