### PR TITLE
Add supabase-community/gotrue-swift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3720,6 +3720,7 @@
   "https://github.com/sunlubo/swiftsdl2.git",
   "https://github.com/sunshinejr/Moya-ModelMapper.git",
   "https://github.com/sunshinejr/SwiftyUserDefaults.git",
+  "https://github.com/supabase-community/gotrue-swift.git",
   "https://github.com/supabase-community/postgrest-swift.git",
   "https://github.com/superk589/RijndaelSwift.git",
   "https://github.com/superpeteblaze/ScalingCarousel.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [gotrue-swift](https://github.com/supabase-community/gotrue-swift)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
