### PR TITLE
Adding Neon

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -722,6 +722,7 @@
   "https://github.com/ChimeHQ/LanguageServerProtocol.git",
   "https://github.com/ChimeHQ/Meter.git",
   "https://github.com/ChimeHQ/MeterReporter.git",
+  "https://github.com/ChimeHQ/Neon.git",
   "https://github.com/ChimeHQ/NicerTouchBar.git",
   "https://github.com/ChimeHQ/OperationPlus.git",
   "https://github.com/ChimeHQ/ProcessEnv.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Neon](https://github.com/ChimeHQ/Neon)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
