### PR TITLE
Add StubNetworkingSwift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -43,6 +43,7 @@
   "https://github.com/3qax/swiftyoled.git",
   "https://github.com/417-72KI/MockUserDefaults.git",
   "https://github.com/417-72KI/MultipartFormDataParser.git",
+  "https://github.com/417-72KI/StubNetworkingSwift.git",
   "https://github.com/417-72KI/SwiftUtilities.git",
   "https://github.com/8rightside/Resistance.git",
   "https://github.com/a2/MessagePack.swift.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [StubNetworkingSwift](https://github.com/417-72KI/StubNetworkingSwift)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
