### PR TITLE
Automatic retry

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,9 +50,13 @@ jobs:
           name: artifact
 
       - name: Check redirect
-        run: |
-          chmod +x ./validator
-          ./validator check-redirects -i packages.json -o redirect-checked.json
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-redirects -i packages.json -o redirect-checked.json
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -79,9 +83,13 @@ jobs:
           name: artifact
 
       - name: Check dependencies
-        run: |
-          chmod +x ./validator
-          ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -109,9 +117,13 @@ jobs:
           name: artifact
 
       - name: Check dependencies
-        run: |
-          chmod +x ./validator
-          ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -139,9 +151,13 @@ jobs:
           name: artifact
 
       - name: Check dependencies
-        run: |
-          chmod +x ./validator
-          ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -169,9 +185,13 @@ jobs:
           name: artifact
 
       - name: Check dependencies
-        run: |
-          chmod +x ./validator
-          ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -199,9 +219,13 @@ jobs:
           name: artifact
 
       - name: Check dependencies
-        run: |
-          chmod +x ./validator
-          ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -229,9 +253,13 @@ jobs:
           name: artifact
 
       - name: Check dependencies
-        run: |
-          chmod +x ./validator
-          ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -259,9 +287,13 @@ jobs:
           name: artifact
 
       - name: Check dependencies
-        run: |
-          chmod +x ./validator
-          ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -289,9 +321,13 @@ jobs:
           name: artifact
 
       - name: Check dependencies
-        run: |
-          chmod +x ./validator
-          ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -319,9 +355,13 @@ jobs:
           name: artifact
 
       - name: Check dependencies
-        run: |
-          chmod +x ./validator
-          ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -354,12 +394,16 @@ jobs:
           name: artifact
 
       - name: Check dependencies
-        run: |
-          chmod +x ./validator
-          ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-          ./validator merge-lists out_*.json -o packages.json
-          # artifacts from appearing in the PR
-          rm out_*.json redirect-checked.json validator .packageDumpCache
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+            ./validator merge-lists out_*.json -o packages.json
+            # artifacts from appearing in the PR
+            rm out_*.json redirect-checked.json validator .packageDumpCache
 
       - name: Create pull request
         id: cpr


### PR DESCRIPTION
We're getting occasional errors when running the checks, like for instance

```
/home/runner/work/_temp/f71bafec-5da3-4296-adfe-8c54ea18e1e8.sh: line 2:  1675 Segmentation fault      (core dumped) ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
```

Sometimes it's a segfault but not always. It doesn't strike me like something that's wrong with the program itself, because we're not using dynamic memory allocation and unsafe pointers. So crashes like this would probably indicate a library or environment problem.

I've never seen crashes like this when running locally but I've also never run a full cycle locally. Either way, this is hard to debug and not worth the time at its current frequency. Best just paper it over for now. Having broken down the job into 10 steps makes this possible with much less overhead than before.