### PR TITLE
Remove https://github.com/Azure/azure-sdk-for-ios.git

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -456,7 +456,6 @@
   "https://github.com/aydenp/passencoder.git",
   "https://github.com/Azoy/Sword.git",
   "https://github.com/Azoy/SwordRPC.git",
-  "https://github.com/Azure/azure-sdk-for-ios.git",
   "https://github.com/AzureAD/microsoft-authentication-library-for-objc.git",
   "https://github.com/b3ll/Decomposed.git",
   "https://github.com/b3ll/Motion.git",


### PR DESCRIPTION
Fixes #2444

The delete package actions seems to be broken.