### PR TITLE
Add CacheStore SPM

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -22,6 +22,7 @@
   "https://github.com/0xLet/SwiftUIKit.git",
   "https://github.com/0xLet/WTV.git",
   "https://github.com/0xOpenBytes/c.git",
+  "https://github.com/0xOpenBytes/CacheStore.git",
   "https://github.com/0xOpenBytes/FLet.git",
   "https://github.com/0xOpenBytes/o.git",
   "https://github.com/0xOpenBytes/t.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [CacheStore](https://github.com/0xOpenBytes/CacheStore)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
