### PR TITLE
Removed trailing slash.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -442,7 +442,7 @@
   "https://github.com/AudioKit/SoundpipeAudioKit.git",
   "https://github.com/AudioKit/SporthAudioKit.git",
   "https://github.com/AudioKit/STKAudioKit.git",
-  "https://github.com/AudioKit/Tonic.git/",
+  "https://github.com/AudioKit/Tonic.git",
   "https://github.com/aus-der-Technik/SwiftyNats.git",
   "https://github.com/auth0/Auth0.swift.git",
   "https://github.com/auth0/JWTDecode.swift.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
