### PR TITLE
Use Swift 5.7 nightly to start accepting 5.7 only packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     types: [submitted]
 
 env:
-  SWIFT_IMAGE: swift:5.6-focal
+  SWIFT_IMAGE: swiftlang/swift:nightly-5.7-focal
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened]
 
 env:
-  SWIFT_IMAGE: swift:5.6-focal
+  SWIFT_IMAGE: swiftlang/swift:nightly-5.7-focal
 
 jobs:
   add:


### PR DESCRIPTION
This should get us started adding 5.7-only packages in the index, even if we don't build them yet.

The validator can't be switched over yet, because it uses the GH action `fwal/setup-swift` which doesn't support nightlies. This shouldn't be a problem. It'll raise errors in its run logs for these packages but won't try to mark them for removal (which wouldn't be an issue even if it did, we could just ignore the nightly for a week or so).