### PR TITLE
Add fummicc1/AsyncDownSamplingImage

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1819,6 +1819,7 @@
   "https://github.com/FullQueueDeveloper/Swish.git",
   "https://github.com/fumito-ito/SwiftyInAppMessaging.git",
   "https://github.com/fumito-ito/SwiftyRemoteConfig.git",
+  "https://github.com/fummicc1/AsyncDownSamplingImage.git",
   "https://github.com/fummicc1/csv2img.git",
   "https://github.com/fummicc1/EasyFirebaseSwift.git",
   "https://github.com/fummicc1/MoyaAPIClient.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [fummicc1/AsyncDownSamplingImage](fummicc1/AsyncDownSamplingImage)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
