### PR TITLE
Patch 'Remove Package' script to support denylist

### DIFF
--- a/.github/remove_package.sh
+++ b/.github/remove_package.sh
@@ -34,4 +34,9 @@ echo "${GH_BODY}" | while read url ; do
     jq 'del(.[] | select((.|ascii_downcase) == ("'$url'"|ascii_downcase)))' packages.json > temp.json
     mv temp.json packages.json
     echo "- '$url'."
+
+    # 1e. Add Item to Denylist
+    jq '. |= . + [{"package_url": "'$url'", "notes": "Requested in https://github.com/SwiftPackageIndex/PackageList/issues/'$GH_ISSUE'."}]' -S denylist.json > temp.json
+    mv temp.json denylist.json
+    echo "+ '$url' (denylist)."
 done

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -88,6 +88,7 @@ jobs:
         run: bash .github/remove_package.sh
         env:
           GH_BODY: ${{ github.event.issue.body }}
+          GH_ISSUE: ${{ github.event.issue.number }}
 
       - name: Validate JSON
         run: docker run --rm --env CI=true -v "$PWD:/host" -w /host $SWIFT_IMAGE swift validate.swift


### PR DESCRIPTION
With the recent introduction of the 'denylist', the "Remove Package" script will almost never truly work. This should hopefully patch that (not that it's likely to be used commonly).

Worth noting that as JQ likes to sort keys alphabetically, on first run this will move notes before package_url but should keep the order of elements within the main array constant.