### PR TITLE
Add swift-msgpack

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3550,6 +3550,7 @@
   "https://github.com/nks5117/KatexUtils.git",
   "https://github.com/nlampi/SwiftGridView.git",
   "https://github.com/nmdias/FeedKit.git",
+  "https://github.com/nnabeyang/swift-msgpack.git",
   "https://github.com/nnsnodnb/MultipleImageView.git",
   "https://github.com/NobodyNada/Clibevent.git",
   "https://github.com/NobodyNada/Clibuv.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [swift-msgpack](https://github.com/nnabeyang/swift-msgpack)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
