### PR TITLE
renaming automerge-swift repo

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -538,7 +538,7 @@
   "https://github.com/auth0/SimpleKeychain.git",
   "https://github.com/autobahnswift/shuttle.git",
   "https://github.com/automatontec/jsonconfig.git",
-  "https://github.com/automerge/automerge-swifter.git",
+  "https://github.com/automerge/automerge-swift.git",
   "https://github.com/autoreleasefool/hive-engine.git",
   "https://github.com/autoreleasefool/hive-mind.git",
   "https://github.com/autozimu/stringmetric.swift.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Automerge](https://github.com/automerge/automerge-swift.git)

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
