### PR TITLE
Bump swift version to nightly-5.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     types: [submitted]
 
 env:
-  SWIFT_IMAGE: swift:5.8-focal
+  SWIFT_IMAGE: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened]
 
 env:
-  SWIFT_IMAGE: swift:5.8-focal
+  SWIFT_IMAGE: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
 
 jobs:
   add:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,40 +31,36 @@ jobs:
             validator
 
 
-  # check_redirects_0:
-  #   needs: build_validator
-  #   env:
-  #     CHUNK: "0"
-  #     OUTPUT_FILE: out_0.json
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: swift-actions/setup-swift@main
-  #       with:
-  #         swift-version: ${{ env.SWIFT_VERSION }}
+  check_redirects_0:
+    needs: build_validator
+    env:
+      CHUNK: "0"
+      OUTPUT_FILE: out_0.json
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
 
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: artifact
+      - name: Check redirect
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-redirects -i packages.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks 2
 
-  #     - name: Check redirect
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 60
-  #         max_attempts: 3
-  #         retry_on: error
-  #         command: |
-  #           chmod +x ./validator
-  #           ./validator check-redirects -i packages.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks 2
-
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         path: |
-  #           ${{ env.OUTPUT_FILE }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            ${{ env.OUTPUT_FILE }}
 
 
   # check_redirects_1:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,14 +8,14 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   NUMBER_OF_CHUNKS: "12"
+  SWIFT_IMAGE: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
 
 jobs:
 
   build_validator:
     runs-on: ubuntu-latest
     container:
-      # FIXME: change to nightly
-      image: swift:5.8.1-focal
+      image: ${{ env.SWIFT_IMAGE }}
     steps:
       - name: Build validator
         run: |
@@ -38,8 +38,7 @@ jobs:
       OUTPUT_FILE: out_0.json
     runs-on: ubuntu-latest
     container:
-      # FIXME: change to nightly
-      image: swift:5.8.1-focal
+      image: ${{ env.SWIFT_IMAGE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,19 +7,16 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # see https://github.com/actions/virtual-environments for available environments
-  SWIFT_VERSION: "5.8"
   NUMBER_OF_CHUNKS: "12"
 
 jobs:
 
   build_validator:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      # FIXME: change to nightly
+      image: swift:5.8.1-focal
     steps:
-      - uses: swift-actions/setup-swift@main
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
-
       - name: Build validator
         run: |
           git clone https://github.com/SwiftPackageIndex/PackageList-Validator.git --depth 1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,514 +34,514 @@ jobs:
             validator
 
 
-  check_redirects_0:
-    needs: build_validator
-    env:
-      CHUNK: "0"
-      OUTPUT_FILE: out_0.json
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: swift-actions/setup-swift@main
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
-
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-
-      - name: Check redirect
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          retry_on: error
-          command: |
-            chmod +x ./validator
-            ./validator check-redirects -i packages.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks 2
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: |
-            ${{ env.OUTPUT_FILE }}
-
-
-  check_redirects_1:
-    needs: check_redirects_0
-    env:
-      CHUNK: "1"
-      OUTPUT_FILE: out_1.json
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: swift-actions/setup-swift@main
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
-
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-
-      - name: Check redirect
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          retry_on: error
-          command: |
-            chmod +x ./validator
-            ./validator check-redirects -i packages.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks 2
-            ./validator merge-lists out_*.json -o redirect-checked.json
-            rm out_*.json
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: |
-            redirect-checked.json
-
-
-  check_dependencies_0:
-    needs: check_redirects_1  # reference previous step
-    env:
-      CHUNK: "0"
-      OUTPUT_FILE: out_0.json
-    # -- common --
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: swift-actions/setup-swift@main
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-
-      - name: Check dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          retry_on: error
-          command: |
-            chmod +x ./validator
-            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: |
-            ${{ env.OUTPUT_FILE }}
-            .packageDumpCache
-
-
-  check_dependencies_1:
-    needs: check_dependencies_0  # reference previous step
-    env:
-      CHUNK: "1"
-      OUTPUT_FILE: out_1.json
-    # -- common --
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: swift-actions/setup-swift@main
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-
-      - name: Check dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          retry_on: error
-          command: |
-            chmod +x ./validator
-            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: |
-            ${{ env.OUTPUT_FILE }}
-            .packageDumpCache
-
-
-  check_dependencies_2:
-    needs: check_dependencies_1  # reference previous step
-    env:
-      CHUNK: "2"
-      OUTPUT_FILE: out_2.json
-    # -- common --
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: swift-actions/setup-swift@main
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-
-      - name: Check dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          retry_on: error
-          command: |
-            chmod +x ./validator
-            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: |
-            ${{ env.OUTPUT_FILE }}
-            .packageDumpCache
-
-
-  check_dependencies_3:
-    needs: check_dependencies_2  # reference previous step
-    env:
-      CHUNK: "3"
-      OUTPUT_FILE: out_3.json
-    # -- common --
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: swift-actions/setup-swift@main
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-
-      - name: Check dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          retry_on: error
-          command: |
-            chmod +x ./validator
-            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: |
-            ${{ env.OUTPUT_FILE }}
-            .packageDumpCache
-
-
-  check_dependencies_4:
-    needs: check_dependencies_3  # reference previous step
-    env:
-      CHUNK: "4"
-      OUTPUT_FILE: out_4.json
-    # -- common --
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: swift-actions/setup-swift@main
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-
-      - name: Check dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          retry_on: error
-          command: |
-            chmod +x ./validator
-            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: |
-            ${{ env.OUTPUT_FILE }}
-            .packageDumpCache
-
-
-  check_dependencies_5:
-    needs: check_dependencies_4  # reference previous step
-    env:
-      CHUNK: "5"
-      OUTPUT_FILE: out_5.json
-    # -- common --
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: swift-actions/setup-swift@main
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-
-      - name: Check dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          retry_on: error
-          command: |
-            chmod +x ./validator
-            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: |
-            ${{ env.OUTPUT_FILE }}
-            .packageDumpCache
-
-
-  check_dependencies_6:
-    needs: check_dependencies_5  # reference previous step
-    env:
-      CHUNK: "6"
-      OUTPUT_FILE: out_6.json
-    # -- common --
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: swift-actions/setup-swift@main
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-
-      - name: Check dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          retry_on: error
-          command: |
-            chmod +x ./validator
-            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: |
-            ${{ env.OUTPUT_FILE }}
-            .packageDumpCache
-
-
-  check_dependencies_7:
-    needs: check_dependencies_6  # reference previous step
-    env:
-      CHUNK: "7"
-      OUTPUT_FILE: out_7.json
-    # -- common --
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: swift-actions/setup-swift@main
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-
-      - name: Check dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          retry_on: error
-          command: |
-            chmod +x ./validator
-            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: |
-            ${{ env.OUTPUT_FILE }}
-            .packageDumpCache
-
-
-  check_dependencies_8:
-    needs: check_dependencies_7  # reference previous step
-    env:
-      CHUNK: "8"
-      OUTPUT_FILE: out_8.json
-    # -- common --
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: swift-actions/setup-swift@main
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-
-      - name: Check dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          retry_on: error
-          command: |
-            chmod +x ./validator
-            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: |
-            ${{ env.OUTPUT_FILE }}
-            .packageDumpCache
-
-
-  check_dependencies_9:
-    needs: check_dependencies_8  # reference previous step
-    env:
-      CHUNK: "9"
-      OUTPUT_FILE: out_9.json
-    # -- common --
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: swift-actions/setup-swift@main
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-
-      - name: Check dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          retry_on: error
-          command: |
-            chmod +x ./validator
-            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: |
-            ${{ env.OUTPUT_FILE }}
-            .packageDumpCache
-
-
-  check_dependencies_10:
-    needs: check_dependencies_9  # reference previous step
-    env:
-      CHUNK: "10"
-      OUTPUT_FILE: out_10.json
-    # -- common --
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: swift-actions/setup-swift@main
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-
-      - name: Check dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          retry_on: error
-          command: |
-            chmod +x ./validator
-            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: |
-            ${{ env.OUTPUT_FILE }}
-            .packageDumpCache
-
-
-  # $NUMBER_OF_CHUNKS - 1
-  check_dependencies_last:
-    needs: check_dependencies_10 # $NUMBER_OF_CHUNKS - 2
-    runs-on: ubuntu-20.04
-    env:
-      CHUNK: "9"                 # $NUMBER_OF_CHUNKS - 1
-      OUTPUT_FILE: out_9.json    # $NUMBER_OF_CHUNKS - 1
-    # -- end of config --
-    steps:
-      - uses: swift-actions/setup-swift@main
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
-
-      # we need to check out the repo in the last step in order to create a PR
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-
-      - name: Check dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          retry_on: error
-          command: |
-            chmod +x ./validator
-            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-            ./validator merge-lists out_*.json -o packages.json
-            # artifacts from appearing in the PR
-            rm out_*.json redirect-checked.json validator .packageDumpCache
-
-      - name: Create pull request
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Updated Packages
-          title: '[Nightly] Updated Packages'
-          body: |
-            :robot: This is an automated change
+  # check_redirects_0:
+  #   needs: build_validator
+  #   env:
+  #     CHUNK: "0"
+  #     OUTPUT_FILE: out_0.json
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: swift-actions/setup-swift@main
+  #       with:
+  #         swift-version: ${{ env.SWIFT_VERSION }}
+
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+
+  #     - name: Check redirect
+  #       uses: nick-fields/retry@v2
+  #       with:
+  #         timeout_minutes: 60
+  #         max_attempts: 3
+  #         retry_on: error
+  #         command: |
+  #           chmod +x ./validator
+  #           ./validator check-redirects -i packages.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks 2
+
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         path: |
+  #           ${{ env.OUTPUT_FILE }}
+
+
+  # check_redirects_1:
+  #   needs: check_redirects_0
+  #   env:
+  #     CHUNK: "1"
+  #     OUTPUT_FILE: out_1.json
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: swift-actions/setup-swift@main
+  #       with:
+  #         swift-version: ${{ env.SWIFT_VERSION }}
+
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+
+  #     - name: Check redirect
+  #       uses: nick-fields/retry@v2
+  #       with:
+  #         timeout_minutes: 60
+  #         max_attempts: 3
+  #         retry_on: error
+  #         command: |
+  #           chmod +x ./validator
+  #           ./validator check-redirects -i packages.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks 2
+  #           ./validator merge-lists out_*.json -o redirect-checked.json
+  #           rm out_*.json
+
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         path: |
+  #           redirect-checked.json
+
+
+  # check_dependencies_0:
+  #   needs: check_redirects_1  # reference previous step
+  #   env:
+  #     CHUNK: "0"
+  #     OUTPUT_FILE: out_0.json
+  #   # -- common --
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: swift-actions/setup-swift@main
+  #       with:
+  #         swift-version: ${{ env.SWIFT_VERSION }}
+
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+
+  #     - name: Check dependencies
+  #       uses: nick-fields/retry@v2
+  #       with:
+  #         timeout_minutes: 60
+  #         max_attempts: 3
+  #         retry_on: error
+  #         command: |
+  #           chmod +x ./validator
+  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         path: |
+  #           ${{ env.OUTPUT_FILE }}
+  #           .packageDumpCache
+
+
+  # check_dependencies_1:
+  #   needs: check_dependencies_0  # reference previous step
+  #   env:
+  #     CHUNK: "1"
+  #     OUTPUT_FILE: out_1.json
+  #   # -- common --
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: swift-actions/setup-swift@main
+  #       with:
+  #         swift-version: ${{ env.SWIFT_VERSION }}
+
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+
+  #     - name: Check dependencies
+  #       uses: nick-fields/retry@v2
+  #       with:
+  #         timeout_minutes: 60
+  #         max_attempts: 3
+  #         retry_on: error
+  #         command: |
+  #           chmod +x ./validator
+  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         path: |
+  #           ${{ env.OUTPUT_FILE }}
+  #           .packageDumpCache
+
+
+  # check_dependencies_2:
+  #   needs: check_dependencies_1  # reference previous step
+  #   env:
+  #     CHUNK: "2"
+  #     OUTPUT_FILE: out_2.json
+  #   # -- common --
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: swift-actions/setup-swift@main
+  #       with:
+  #         swift-version: ${{ env.SWIFT_VERSION }}
+
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+
+  #     - name: Check dependencies
+  #       uses: nick-fields/retry@v2
+  #       with:
+  #         timeout_minutes: 60
+  #         max_attempts: 3
+  #         retry_on: error
+  #         command: |
+  #           chmod +x ./validator
+  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         path: |
+  #           ${{ env.OUTPUT_FILE }}
+  #           .packageDumpCache
+
+
+  # check_dependencies_3:
+  #   needs: check_dependencies_2  # reference previous step
+  #   env:
+  #     CHUNK: "3"
+  #     OUTPUT_FILE: out_3.json
+  #   # -- common --
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: swift-actions/setup-swift@main
+  #       with:
+  #         swift-version: ${{ env.SWIFT_VERSION }}
+
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+
+  #     - name: Check dependencies
+  #       uses: nick-fields/retry@v2
+  #       with:
+  #         timeout_minutes: 60
+  #         max_attempts: 3
+  #         retry_on: error
+  #         command: |
+  #           chmod +x ./validator
+  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         path: |
+  #           ${{ env.OUTPUT_FILE }}
+  #           .packageDumpCache
+
+
+  # check_dependencies_4:
+  #   needs: check_dependencies_3  # reference previous step
+  #   env:
+  #     CHUNK: "4"
+  #     OUTPUT_FILE: out_4.json
+  #   # -- common --
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: swift-actions/setup-swift@main
+  #       with:
+  #         swift-version: ${{ env.SWIFT_VERSION }}
+
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+
+  #     - name: Check dependencies
+  #       uses: nick-fields/retry@v2
+  #       with:
+  #         timeout_minutes: 60
+  #         max_attempts: 3
+  #         retry_on: error
+  #         command: |
+  #           chmod +x ./validator
+  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         path: |
+  #           ${{ env.OUTPUT_FILE }}
+  #           .packageDumpCache
+
+
+  # check_dependencies_5:
+  #   needs: check_dependencies_4  # reference previous step
+  #   env:
+  #     CHUNK: "5"
+  #     OUTPUT_FILE: out_5.json
+  #   # -- common --
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: swift-actions/setup-swift@main
+  #       with:
+  #         swift-version: ${{ env.SWIFT_VERSION }}
+
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+
+  #     - name: Check dependencies
+  #       uses: nick-fields/retry@v2
+  #       with:
+  #         timeout_minutes: 60
+  #         max_attempts: 3
+  #         retry_on: error
+  #         command: |
+  #           chmod +x ./validator
+  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         path: |
+  #           ${{ env.OUTPUT_FILE }}
+  #           .packageDumpCache
+
+
+  # check_dependencies_6:
+  #   needs: check_dependencies_5  # reference previous step
+  #   env:
+  #     CHUNK: "6"
+  #     OUTPUT_FILE: out_6.json
+  #   # -- common --
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: swift-actions/setup-swift@main
+  #       with:
+  #         swift-version: ${{ env.SWIFT_VERSION }}
+
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+
+  #     - name: Check dependencies
+  #       uses: nick-fields/retry@v2
+  #       with:
+  #         timeout_minutes: 60
+  #         max_attempts: 3
+  #         retry_on: error
+  #         command: |
+  #           chmod +x ./validator
+  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         path: |
+  #           ${{ env.OUTPUT_FILE }}
+  #           .packageDumpCache
+
+
+  # check_dependencies_7:
+  #   needs: check_dependencies_6  # reference previous step
+  #   env:
+  #     CHUNK: "7"
+  #     OUTPUT_FILE: out_7.json
+  #   # -- common --
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: swift-actions/setup-swift@main
+  #       with:
+  #         swift-version: ${{ env.SWIFT_VERSION }}
+
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+
+  #     - name: Check dependencies
+  #       uses: nick-fields/retry@v2
+  #       with:
+  #         timeout_minutes: 60
+  #         max_attempts: 3
+  #         retry_on: error
+  #         command: |
+  #           chmod +x ./validator
+  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         path: |
+  #           ${{ env.OUTPUT_FILE }}
+  #           .packageDumpCache
+
+
+  # check_dependencies_8:
+  #   needs: check_dependencies_7  # reference previous step
+  #   env:
+  #     CHUNK: "8"
+  #     OUTPUT_FILE: out_8.json
+  #   # -- common --
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: swift-actions/setup-swift@main
+  #       with:
+  #         swift-version: ${{ env.SWIFT_VERSION }}
+
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+
+  #     - name: Check dependencies
+  #       uses: nick-fields/retry@v2
+  #       with:
+  #         timeout_minutes: 60
+  #         max_attempts: 3
+  #         retry_on: error
+  #         command: |
+  #           chmod +x ./validator
+  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         path: |
+  #           ${{ env.OUTPUT_FILE }}
+  #           .packageDumpCache
+
+
+  # check_dependencies_9:
+  #   needs: check_dependencies_8  # reference previous step
+  #   env:
+  #     CHUNK: "9"
+  #     OUTPUT_FILE: out_9.json
+  #   # -- common --
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: swift-actions/setup-swift@main
+  #       with:
+  #         swift-version: ${{ env.SWIFT_VERSION }}
+
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+
+  #     - name: Check dependencies
+  #       uses: nick-fields/retry@v2
+  #       with:
+  #         timeout_minutes: 60
+  #         max_attempts: 3
+  #         retry_on: error
+  #         command: |
+  #           chmod +x ./validator
+  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         path: |
+  #           ${{ env.OUTPUT_FILE }}
+  #           .packageDumpCache
+
+
+  # check_dependencies_10:
+  #   needs: check_dependencies_9  # reference previous step
+  #   env:
+  #     CHUNK: "10"
+  #     OUTPUT_FILE: out_10.json
+  #   # -- common --
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: swift-actions/setup-swift@main
+  #       with:
+  #         swift-version: ${{ env.SWIFT_VERSION }}
+
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+
+  #     - name: Check dependencies
+  #       uses: nick-fields/retry@v2
+  #       with:
+  #         timeout_minutes: 60
+  #         max_attempts: 3
+  #         retry_on: error
+  #         command: |
+  #           chmod +x ./validator
+  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         path: |
+  #           ${{ env.OUTPUT_FILE }}
+  #           .packageDumpCache
+
+
+  # # $NUMBER_OF_CHUNKS - 1
+  # check_dependencies_last:
+  #   needs: check_dependencies_10 # $NUMBER_OF_CHUNKS - 2
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     CHUNK: "9"                 # $NUMBER_OF_CHUNKS - 1
+  #     OUTPUT_FILE: out_9.json    # $NUMBER_OF_CHUNKS - 1
+  #   # -- end of config --
+  #   steps:
+  #     - uses: swift-actions/setup-swift@main
+  #       with:
+  #         swift-version: ${{ env.SWIFT_VERSION }}
+
+  #     # we need to check out the repo in the last step in order to create a PR
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+
+  #     - name: Check dependencies
+  #       uses: nick-fields/retry@v2
+  #       with:
+  #         timeout_minutes: 60
+  #         max_attempts: 3
+  #         retry_on: error
+  #         command: |
+  #           chmod +x ./validator
+  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+  #           ./validator merge-lists out_*.json -o packages.json
+  #           # artifacts from appearing in the PR
+  #           rm out_*.json redirect-checked.json validator .packageDumpCache
+
+  #     - name: Create pull request
+  #       id: cpr
+  #       uses: peter-evans/create-pull-request@v5
+  #       with:
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         commit-message: Updated Packages
+  #         title: '[Nightly] Updated Packages'
+  #         body: |
+  #           :robot: This is an automated change
             
-            - Removed any redirects
-            - Removed any duplicates
-            - Removed any deleted repositories
-            - Added any unknown dependencies
+  #           - Removed any redirects
+  #           - Removed any duplicates
+  #           - Removed any deleted repositories
+  #           - Added any unknown dependencies
 
-      - name: Check outputs
-        run: echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+  #     - name: Check outputs
+  #       run: echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,14 +8,13 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   NUMBER_OF_CHUNKS: "12"
-  SWIFT_IMAGE: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
 
 jobs:
 
   build_validator:
     runs-on: ubuntu-latest
     container:
-      image: ${{ env.SWIFT_IMAGE }}
+      image: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
     steps:
       - name: Build validator
         run: |
@@ -38,7 +37,7 @@ jobs:
       OUTPUT_FILE: out_0.json
     runs-on: ubuntu-latest
     container:
-      image: ${{ env.SWIFT_IMAGE }}
+      image: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -65,478 +64,452 @@ jobs:
             ${{ env.OUTPUT_FILE }}
 
 
-  # check_redirects_1:
-  #   needs: check_redirects_0
-  #   env:
-  #     CHUNK: "1"
-  #     OUTPUT_FILE: out_1.json
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: swift-actions/setup-swift@main
-  #       with:
-  #         swift-version: ${{ env.SWIFT_VERSION }}
-
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: artifact
-
-  #     - name: Check redirect
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 60
-  #         max_attempts: 3
-  #         retry_on: error
-  #         command: |
-  #           chmod +x ./validator
-  #           ./validator check-redirects -i packages.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks 2
-  #           ./validator merge-lists out_*.json -o redirect-checked.json
-  #           rm out_*.json
-
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         path: |
-  #           redirect-checked.json
-
-
-  # check_dependencies_0:
-  #   needs: check_redirects_1  # reference previous step
-  #   env:
-  #     CHUNK: "0"
-  #     OUTPUT_FILE: out_0.json
-  #   # -- common --
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: swift-actions/setup-swift@main
-  #       with:
-  #         swift-version: ${{ env.SWIFT_VERSION }}
-
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: artifact
-
-  #     - name: Check dependencies
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 60
-  #         max_attempts: 3
-  #         retry_on: error
-  #         command: |
-  #           chmod +x ./validator
-  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         path: |
-  #           ${{ env.OUTPUT_FILE }}
-  #           .packageDumpCache
-
-
-  # check_dependencies_1:
-  #   needs: check_dependencies_0  # reference previous step
-  #   env:
-  #     CHUNK: "1"
-  #     OUTPUT_FILE: out_1.json
-  #   # -- common --
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: swift-actions/setup-swift@main
-  #       with:
-  #         swift-version: ${{ env.SWIFT_VERSION }}
-
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: artifact
-
-  #     - name: Check dependencies
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 60
-  #         max_attempts: 3
-  #         retry_on: error
-  #         command: |
-  #           chmod +x ./validator
-  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         path: |
-  #           ${{ env.OUTPUT_FILE }}
-  #           .packageDumpCache
-
-
-  # check_dependencies_2:
-  #   needs: check_dependencies_1  # reference previous step
-  #   env:
-  #     CHUNK: "2"
-  #     OUTPUT_FILE: out_2.json
-  #   # -- common --
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: swift-actions/setup-swift@main
-  #       with:
-  #         swift-version: ${{ env.SWIFT_VERSION }}
-
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: artifact
-
-  #     - name: Check dependencies
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 60
-  #         max_attempts: 3
-  #         retry_on: error
-  #         command: |
-  #           chmod +x ./validator
-  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         path: |
-  #           ${{ env.OUTPUT_FILE }}
-  #           .packageDumpCache
-
-
-  # check_dependencies_3:
-  #   needs: check_dependencies_2  # reference previous step
-  #   env:
-  #     CHUNK: "3"
-  #     OUTPUT_FILE: out_3.json
-  #   # -- common --
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: swift-actions/setup-swift@main
-  #       with:
-  #         swift-version: ${{ env.SWIFT_VERSION }}
-
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: artifact
-
-  #     - name: Check dependencies
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 60
-  #         max_attempts: 3
-  #         retry_on: error
-  #         command: |
-  #           chmod +x ./validator
-  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         path: |
-  #           ${{ env.OUTPUT_FILE }}
-  #           .packageDumpCache
-
-
-  # check_dependencies_4:
-  #   needs: check_dependencies_3  # reference previous step
-  #   env:
-  #     CHUNK: "4"
-  #     OUTPUT_FILE: out_4.json
-  #   # -- common --
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: swift-actions/setup-swift@main
-  #       with:
-  #         swift-version: ${{ env.SWIFT_VERSION }}
-
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: artifact
-
-  #     - name: Check dependencies
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 60
-  #         max_attempts: 3
-  #         retry_on: error
-  #         command: |
-  #           chmod +x ./validator
-  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         path: |
-  #           ${{ env.OUTPUT_FILE }}
-  #           .packageDumpCache
-
-
-  # check_dependencies_5:
-  #   needs: check_dependencies_4  # reference previous step
-  #   env:
-  #     CHUNK: "5"
-  #     OUTPUT_FILE: out_5.json
-  #   # -- common --
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: swift-actions/setup-swift@main
-  #       with:
-  #         swift-version: ${{ env.SWIFT_VERSION }}
-
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: artifact
-
-  #     - name: Check dependencies
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 60
-  #         max_attempts: 3
-  #         retry_on: error
-  #         command: |
-  #           chmod +x ./validator
-  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         path: |
-  #           ${{ env.OUTPUT_FILE }}
-  #           .packageDumpCache
-
-
-  # check_dependencies_6:
-  #   needs: check_dependencies_5  # reference previous step
-  #   env:
-  #     CHUNK: "6"
-  #     OUTPUT_FILE: out_6.json
-  #   # -- common --
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: swift-actions/setup-swift@main
-  #       with:
-  #         swift-version: ${{ env.SWIFT_VERSION }}
-
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: artifact
-
-  #     - name: Check dependencies
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 60
-  #         max_attempts: 3
-  #         retry_on: error
-  #         command: |
-  #           chmod +x ./validator
-  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         path: |
-  #           ${{ env.OUTPUT_FILE }}
-  #           .packageDumpCache
-
-
-  # check_dependencies_7:
-  #   needs: check_dependencies_6  # reference previous step
-  #   env:
-  #     CHUNK: "7"
-  #     OUTPUT_FILE: out_7.json
-  #   # -- common --
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: swift-actions/setup-swift@main
-  #       with:
-  #         swift-version: ${{ env.SWIFT_VERSION }}
-
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: artifact
-
-  #     - name: Check dependencies
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 60
-  #         max_attempts: 3
-  #         retry_on: error
-  #         command: |
-  #           chmod +x ./validator
-  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         path: |
-  #           ${{ env.OUTPUT_FILE }}
-  #           .packageDumpCache
-
-
-  # check_dependencies_8:
-  #   needs: check_dependencies_7  # reference previous step
-  #   env:
-  #     CHUNK: "8"
-  #     OUTPUT_FILE: out_8.json
-  #   # -- common --
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: swift-actions/setup-swift@main
-  #       with:
-  #         swift-version: ${{ env.SWIFT_VERSION }}
-
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: artifact
-
-  #     - name: Check dependencies
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 60
-  #         max_attempts: 3
-  #         retry_on: error
-  #         command: |
-  #           chmod +x ./validator
-  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         path: |
-  #           ${{ env.OUTPUT_FILE }}
-  #           .packageDumpCache
-
-
-  # check_dependencies_9:
-  #   needs: check_dependencies_8  # reference previous step
-  #   env:
-  #     CHUNK: "9"
-  #     OUTPUT_FILE: out_9.json
-  #   # -- common --
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: swift-actions/setup-swift@main
-  #       with:
-  #         swift-version: ${{ env.SWIFT_VERSION }}
-
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: artifact
-
-  #     - name: Check dependencies
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 60
-  #         max_attempts: 3
-  #         retry_on: error
-  #         command: |
-  #           chmod +x ./validator
-  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         path: |
-  #           ${{ env.OUTPUT_FILE }}
-  #           .packageDumpCache
-
-
-  # check_dependencies_10:
-  #   needs: check_dependencies_9  # reference previous step
-  #   env:
-  #     CHUNK: "10"
-  #     OUTPUT_FILE: out_10.json
-  #   # -- common --
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: swift-actions/setup-swift@main
-  #       with:
-  #         swift-version: ${{ env.SWIFT_VERSION }}
-
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: artifact
-
-  #     - name: Check dependencies
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 60
-  #         max_attempts: 3
-  #         retry_on: error
-  #         command: |
-  #           chmod +x ./validator
-  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         path: |
-  #           ${{ env.OUTPUT_FILE }}
-  #           .packageDumpCache
-
-
-  # # $NUMBER_OF_CHUNKS - 1
-  # check_dependencies_last:
-  #   needs: check_dependencies_10 # $NUMBER_OF_CHUNKS - 2
-  #   runs-on: ubuntu-20.04
-  #   env:
-  #     CHUNK: "9"                 # $NUMBER_OF_CHUNKS - 1
-  #     OUTPUT_FILE: out_9.json    # $NUMBER_OF_CHUNKS - 1
-  #   # -- end of config --
-  #   steps:
-  #     - uses: swift-actions/setup-swift@main
-  #       with:
-  #         swift-version: ${{ env.SWIFT_VERSION }}
-
-  #     # we need to check out the repo in the last step in order to create a PR
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: artifact
-
-  #     - name: Check dependencies
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 60
-  #         max_attempts: 3
-  #         retry_on: error
-  #         command: |
-  #           chmod +x ./validator
-  #           ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
-  #           ./validator merge-lists out_*.json -o packages.json
-  #           # artifacts from appearing in the PR
-  #           rm out_*.json redirect-checked.json validator .packageDumpCache
-
-  #     - name: Create pull request
-  #       id: cpr
-  #       uses: peter-evans/create-pull-request@v5
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         commit-message: Updated Packages
-  #         title: '[Nightly] Updated Packages'
-  #         body: |
-  #           :robot: This is an automated change
+  check_redirects_1:
+    needs: check_redirects_0
+    env:
+      CHUNK: "1"
+      OUTPUT_FILE: out_1.json
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+
+      - name: Check redirect
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-redirects -i packages.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks 2
+            ./validator merge-lists out_*.json -o redirect-checked.json
+            rm out_*.json
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            redirect-checked.json
+
+
+  check_dependencies_0:
+    needs: check_redirects_1  # reference previous step
+    env:
+      CHUNK: "0"
+      OUTPUT_FILE: out_0.json
+    # -- common --
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal  
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+
+      - name: Check dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            ${{ env.OUTPUT_FILE }}
+            .packageDumpCache
+
+
+  check_dependencies_1:
+    needs: check_dependencies_0  # reference previous step
+    env:
+      CHUNK: "1"
+      OUTPUT_FILE: out_1.json
+    # -- common --
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+
+      - name: Check dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            ${{ env.OUTPUT_FILE }}
+            .packageDumpCache
+
+
+  check_dependencies_2:
+    needs: check_dependencies_1  # reference previous step
+    env:
+      CHUNK: "2"
+      OUTPUT_FILE: out_2.json
+    # -- common --
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+
+      - name: Check dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            ${{ env.OUTPUT_FILE }}
+            .packageDumpCache
+
+
+  check_dependencies_3:
+    needs: check_dependencies_2  # reference previous step
+    env:
+      CHUNK: "3"
+      OUTPUT_FILE: out_3.json
+    # -- common --
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+
+      - name: Check dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            ${{ env.OUTPUT_FILE }}
+            .packageDumpCache
+
+
+  check_dependencies_4:
+    needs: check_dependencies_3  # reference previous step
+    env:
+      CHUNK: "4"
+      OUTPUT_FILE: out_4.json
+    # -- common --
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+
+      - name: Check dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            ${{ env.OUTPUT_FILE }}
+            .packageDumpCache
+
+
+  check_dependencies_5:
+    needs: check_dependencies_4  # reference previous step
+    env:
+      CHUNK: "5"
+      OUTPUT_FILE: out_5.json
+    # -- common --
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+
+      - name: Check dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            ${{ env.OUTPUT_FILE }}
+            .packageDumpCache
+
+
+  check_dependencies_6:
+    needs: check_dependencies_5  # reference previous step
+    env:
+      CHUNK: "6"
+      OUTPUT_FILE: out_6.json
+    # -- common --
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+
+      - name: Check dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            ${{ env.OUTPUT_FILE }}
+            .packageDumpCache
+
+
+  check_dependencies_7:
+    needs: check_dependencies_6  # reference previous step
+    env:
+      CHUNK: "7"
+      OUTPUT_FILE: out_7.json
+    # -- common --
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+
+      - name: Check dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            ${{ env.OUTPUT_FILE }}
+            .packageDumpCache
+
+
+  check_dependencies_8:
+    needs: check_dependencies_7  # reference previous step
+    env:
+      CHUNK: "8"
+      OUTPUT_FILE: out_8.json
+    # -- common --
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+
+      - name: Check dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            ${{ env.OUTPUT_FILE }}
+            .packageDumpCache
+
+
+  check_dependencies_9:
+    needs: check_dependencies_8  # reference previous step
+    env:
+      CHUNK: "9"
+      OUTPUT_FILE: out_9.json
+    # -- common --
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+
+      - name: Check dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            ${{ env.OUTPUT_FILE }}
+            .packageDumpCache
+
+
+  check_dependencies_10:
+    needs: check_dependencies_9  # reference previous step
+    env:
+      CHUNK: "10"
+      OUTPUT_FILE: out_10.json
+    # -- common --
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+
+      - name: Check dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            ${{ env.OUTPUT_FILE }}
+            .packageDumpCache
+
+
+  # $NUMBER_OF_CHUNKS - 1
+  check_dependencies_last:
+    needs: check_dependencies_10 # $NUMBER_OF_CHUNKS - 2
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift@sha256:61b96c099daf37c07dd03cc4c7a8c07f41c91df1a6ed8cf3d433387f0a719a9c  # swiftlang/swift:nightly-5.9-focal
+    env:
+      CHUNK: "9"                 # $NUMBER_OF_CHUNKS - 1
+      OUTPUT_FILE: out_9.json    # $NUMBER_OF_CHUNKS - 1
+    # -- end of config --
+    steps:
+      # we need to check out the repo in the last step in order to create a PR
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+
+      - name: Check dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_on: error
+          command: |
+            chmod +x ./validator
+            ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
+            ./validator merge-lists out_*.json -o packages.json
+            # artifacts from appearing in the PR
+            rm out_*.json redirect-checked.json validator .packageDumpCache
+
+      - name: Create pull request
+        id: cpr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Updated Packages
+          title: '[Nightly] Updated Packages'
+          body: |
+            :robot: This is an automated change
             
-  #           - Removed any redirects
-  #           - Removed any duplicates
-  #           - Removed any deleted repositories
-  #           - Added any unknown dependencies
+            - Removed any redirects
+            - Removed any duplicates
+            - Removed any deleted repositories
+            - Added any unknown dependencies
 
-  #     - name: Check outputs
-  #       run: echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+      - name: Check outputs
+        run: echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,10 @@ jobs:
     env:
       CHUNK: "0"
       OUTPUT_FILE: out_0.json
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      # FIXME: change to nightly
+      image: swift:5.8.1-focal
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Not bumping the validator in `nightly.yml`, because it's not easily possible to make the underlying `setup-swift` action we're using to use a nightly swift version.

This means that the nightly will not be able to validate 5.9 only packages at this time (but all the others should keep working).