### PR TITLE
added ChatGPTSwift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1935,6 +1935,7 @@
   "https://github.com/FluxorOrg/FluxorExplorerInterceptor.git",
   "https://github.com/FluxorOrg/FluxorExplorerSnapshot.git",
   "https://github.com/flx/lsm303.git",
+  "https://github.com/flyer2001/ChatGPTSwift.git",
   "https://github.com/fmo91/Pigeon.git",
   "https://github.com/foffer/PwnedPasswords.git",
   "https://github.com/forkercat/MathLib.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [ChatGPTSwift](https://github.com/flyer2001/ChatGPTSwift)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
