### PR TITLE
Add kaascevich/Rapid

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2811,6 +2811,7 @@
   "https://github.com/k-o-d-e-n/ScreenUI.git",
   "https://github.com/kaandedeoglu/KDCircularProgress.git",
   "https://github.com/kaandedeoglu/shark.git",
+  "https://github.com/kaascevich/Rapid.git",
   "https://github.com/kaiede/rpilight.git",
   "https://github.com/Kaiede/SingleBoard.git",
   "https://github.com/kaishin/Gifu.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Rapid](https://github.com/kaascevich/Rapid.git)

## Checklist

I have either:

* [X] Run `swift ./validate.swift`.

Or, checked that:

* [X] The package repositories are publicly accessible.
* [X] The packages all contain a `Package.swift` file in the root folder.
* [X] The packages are written in Swift 5.0 or later.
* [X] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [X] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [X] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [X] The packages all compile without errors.
* [X] The package list JSON file is sorted alphabetically.
