### PR TITLE
Update the nightly package discovery job to be aware of the denylist

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -493,6 +493,13 @@ jobs:
             chmod +x ./validator
             ./validator check-dependencies -i redirect-checked.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks $NUMBER_OF_CHUNKS
             ./validator merge-lists out_*.json -o packages.json
+
+            # Remove anything in the denylist
+            jq --slurpfile denylist denylist.json 'map(select((ascii_downcase as $item | . as $origitem |
+                ($denylist[0] | map(.package_url | ascii_downcase)) | index($item) | not) as $found |
+                if $found then . else empty end))' packages.json > temp.json
+            mv temp.json packages.json
+
             # artifacts from appearing in the PR
             rm out_*.json redirect-checked.json validator .packageDumpCache
 


### PR DESCRIPTION
We may want at some point to include this in the validator, but this should do the trick if I understand how the nightly job wraps up (which I don't, really 😂)