### PR TITLE
Removed amosavian/FileProvider

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -282,7 +282,6 @@
   "https://github.com/amonshiz/NavigationTitle.git",
   "https://github.com/amosavian/AMSMB2.git",
   "https://github.com/amosavian/ExtendedAttributes.git",
-  "https://github.com/amosavian/FileProvider.git",
   "https://github.com/amosavian/LocaleManager.git",
   "https://github.com/amplitude/Amplitude-iOS.git",
   "https://github.com/amplitude/analytics-connector-ios.git",


### PR DESCRIPTION
As of today (18th September 2023) this repo is gone from GitHub for a ToS violation:

![Screenshot 2023-09-18 at 13 29 33@2x](https://github.com/SwiftPackageIndex/PackageList/assets/5180/ed2d1767-637c-4181-b538-7ded32b1384d)
