### PR TITLE
Add mapbox-search-ios

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3646,6 +3646,7 @@
   "https://github.com/mapbox/mapbox-maps-ios.git",
   "https://github.com/mapbox/mapbox-navigation-ios.git",
   "https://github.com/mapbox/mapbox-navigation-native-ios.git",
+  "https://github.com/mapbox/mapbox-search-ios.git",
   "https://github.com/mapbox/mapbox-speech-swift.git",
   "https://github.com/mapbox/turf-swift.git",
   "https://github.com/maplibre/maplibre-gl-native-distribution.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [mapbox-search-ios](https://github.com/mapbox/mapbox-search-ios)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
