### PR TITLE
Reduce limit to 10

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -127,7 +127,7 @@ jobs:
             ./validator check-dependencies2 \
                 --spi-api-token $SPI_API_TOKEN \
                 --input redirect-checked.json --output packages.json \
-                --limit 50
+                --limit 10
             ./validator apply-deny-list -p packages.json -d denylist.json
             # Stop artifacts from appearing in the PR
             rm -f out_*.json redirect-checked.json validator


### PR DESCRIPTION
We've still not caught up, in fact we've hardly made a dent in the backlog:

![CleanShot 2024-01-04 at 18 05 30@2x](https://github.com/SwiftPackageIndex/PackageList/assets/65520/dbdecfae-9aae-40ca-b4a7-15aa9d1a0e5d)

We're tapped out on 5.7/5.8 builds and I've switched over the temp Mac mini to process 5.7/5.8 instead of 5.9 for now to catch up.