### PR TITLE
Run redirect checks concurrently

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,7 +55,7 @@ jobs:
           retry_on: error
           command: |
             chmod +x ./validator
-            ./validator check-redirects -i packages.json -o $redirect-checked.json --concurrency $CONCURRENCY
+            ./validator check-redirects -i packages.json -o redirect-checked.json --concurrency $CONCURRENCY
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,6 +32,7 @@ jobs:
 
 
   check_redirects:
+    needs: build_validator
     env:
       CONCURRENCY: "10"
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,8 +18,7 @@ jobs:
     steps:
       - name: Build validator
         run: |
-          git clone https://github.com/SwiftPackageIndex/PackageList-Validator.git --depth 1 \
-            --branch concurrent-redirect-checks
+          git clone https://github.com/SwiftPackageIndex/PackageList-Validator.git --depth 1
           cd PackageList-Validator
           swift build
           cp $(swift build --show-bin-path)/validator $GITHUB_WORKSPACE/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SPI_API_TOKEN: ${{ secrets.SPI_API_TOKEN }}
-  NUMBER_OF_CHUNKS: "12"
+  CONCURRENCY: "10"
 
 jobs:
 
@@ -19,7 +19,8 @@ jobs:
     steps:
       - name: Build validator
         run: |
-          git clone https://github.com/SwiftPackageIndex/PackageList-Validator.git --depth 1
+          git clone https://github.com/SwiftPackageIndex/PackageList-Validator.git --depth 1 \
+            --branch concurrent-redirect-checks
           cd PackageList-Validator
           swift build
           cp $(swift build --show-bin-path)/validator $GITHUB_WORKSPACE/
@@ -56,7 +57,8 @@ jobs:
           retry_on: error
           command: |
             chmod +x ./validator
-            ./validator check-redirects -i packages.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks 2
+            ./validator check-redirects -i packages.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks 2 \
+              --concurrency $CONCURRENCY
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -90,7 +92,8 @@ jobs:
           retry_on: error
           command: |
             chmod +x ./validator
-            ./validator check-redirects -i packages.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks 2
+            ./validator check-redirects -i packages.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks 2 \
+              --concurrency $CONCURRENCY
             ./validator merge-lists out_*.json -o redirect-checked.json
             rm out_*.json
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,6 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SPI_API_TOKEN: ${{ secrets.SPI_API_TOKEN }}
-  CONCURRENCY: "10"
 
 jobs:
 
@@ -32,11 +31,9 @@ jobs:
             validator
 
 
-  check_redirects_0:
-    needs: build_validator
+  check_redirects:
     env:
-      CHUNK: "0"
-      OUTPUT_FILE: out_0.json
+      CONCURRENCY: "10"
     runs-on: ubuntu-latest
     container:
       image: swift:5.9-jammy
@@ -57,45 +54,7 @@ jobs:
           retry_on: error
           command: |
             chmod +x ./validator
-            ./validator check-redirects -i packages.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks 2 \
-              --concurrency $CONCURRENCY
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: |
-            ${{ env.OUTPUT_FILE }}
-
-
-  check_redirects_1:
-    needs: check_redirects_0
-    env:
-      CHUNK: "1"
-      OUTPUT_FILE: out_1.json
-    runs-on: ubuntu-latest
-    container:
-      image: swift:5.9-jammy
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-
-      - name: Check redirect
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          retry_on: error
-          command: |
-            chmod +x ./validator
-            ./validator check-redirects -i packages.json -o $OUTPUT_FILE --chunk $CHUNK --number-of-chunks 2 \
-              --concurrency $CONCURRENCY
-            ./validator merge-lists out_*.json -o redirect-checked.json
-            rm out_*.json
+            ./validator check-redirects -i packages.json -o $redirect-checked.json --concurrency $CONCURRENCY
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -105,7 +64,7 @@ jobs:
 
 
   check_dependencies:
-    needs: check_redirects_1
+    needs: check_redirects
     runs-on: ubuntu-latest
     container:
       image: swift:5.9-jammy
@@ -133,7 +92,7 @@ jobs:
                 --limit 20
             ./validator apply-deny-list -p packages.json -d denylist.json
             # Stop artifacts from appearing in the PR
-            rm -f out_*.json redirect-checked.json validator
+            rm -f redirect-checked.json validator
       - name: Create pull request
         id: cpr
         uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
Final tweak to the nightly process: running the redirect checks concurrently brings the redirect check run time from ~45min down to ~5mins, and with it the total job time from ~50min to ~11mins.

This allows us also to drop the chunking, which we introduced because we ran up against the 60min per job limit, making the job file simpler yet again.

Before:

![CleanShot 2024-01-12 at 18 13 48@2x](https://github.com/SwiftPackageIndex/PackageList/assets/65520/7fa6ed7e-ea88-4622-885d-b8834caedb47)

After:

![CleanShot 2024-01-12 at 18 18 14@2x](https://github.com/SwiftPackageIndex/PackageList/assets/65520/3d555349-6132-42ab-9ad5-bbbb46df6269)
