### PR TITLE
Don't retry multiple times, log diff

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,12 +50,13 @@ jobs:
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 60
-          max_attempts: 3
+          max_attempts: 1
           retry_on: error
           command: |
             chmod +x ./validator
             ./validator check-redirects -i packages.json -o redirect-checked.json --concurrency $CONCURRENCY
-            diff packages.json redirect-checked.json
+            echo "diff packages.json redirect-checked.json"
+            diff packages.json redirect-checked.json || true
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -83,7 +84,7 @@ jobs:
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 60
-          max_attempts: 3
+          max_attempts: 1
           retry_on: error
           command: |
             chmod +x ./validator

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,6 +55,7 @@ jobs:
           command: |
             chmod +x ./validator
             ./validator check-redirects -i packages.json -o redirect-checked.json --concurrency $CONCURRENCY
+            diff packages.json redirect-checked.json
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
We used to need the retry because the runs were slow but now we want to avoid them so we don't burn through API calls too quickly.