### PR TITLE
Remove swift-testing

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -491,7 +491,6 @@
   "https://github.com/apple/swift-statsd-client.git",
   "https://github.com/apple/swift-syntax.git",
   "https://github.com/apple/swift-system.git",
-  "https://github.com/apple/swift-testing.git",
   "https://github.com/apple/swift-tools-support-async.git",
   "https://github.com/apple/swift-tools-support-core.git",
   "https://github.com/apple/swiftpm-on-llbuild2.git",


### PR DESCRIPTION
See https://forums.swift.org/t/package-swift-testing-is-using-swift-tools-version-5-10-0/69821 and https://github.com/apple/swift-org-website/pull/523 for more context.
