### PR TITLE
Run the nightly job at 8am instead of midnight

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,7 @@ name: Nightly Audit
 on: 
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 8 * * *'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Now that it no longer takes hours, I find that there's often another commit which makes it need a rebase/update before committing. This should enable us to merge without that in most cases.