### PR TITLE
fix: Change CareKitUtilities to CareKitEssentials

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4678,7 +4678,7 @@
   "https://github.com/nerzh/telegram-vapor-bot.git",
   "https://github.com/netguru/ng-ios-network-module.git",
   "https://github.com/netguru/ResponseDetective.git",
-  "https://github.com/netreconlab/CareKitUtilities.git",
+  "https://github.com/netreconlab/CareKitEssentials.git",
   "https://github.com/netreconlab/parse-server-swift.git",
   "https://github.com/netreconlab/Parse-Swift.git",
   "https://github.com/netreconlab/ParseCareKit.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [CareKitEssentials](https://github.com/netreconlab/CareKitEssentials)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
