### PR TITLE
Add initial version of custom package collections file

### DIFF
--- a/custom-package-collections.json
+++ b/custom-package-collections.json
@@ -1,0 +1,20 @@
+[
+    {
+        "name": "SSWG graduated packages",
+        "description": "SSWG packages that are in 'graduated' state",
+        "badge": "SSWG",
+        "url": "https://raw.githubusercontent.com/finestructure/sswg-package-lists/refs/heads/main/graduated.json"
+    },
+    {
+        "name": "SSWG incubating packages",
+        "description": "SSWG packages that are in 'incubating' state",
+        "badge": "SSWG",
+        "url": "https://raw.githubusercontent.com/finestructure/sswg-package-lists/refs/heads/main/incubating.json"
+    },
+    {
+        "name": "SSWG sandbox packages",
+        "description": "SSWG packages that are in 'sandbox' state",
+        "badge": "SSWG",
+        "url": "https://raw.githubusercontent.com/finestructure/sswg-package-lists/refs/heads/main/sandbox.json"
+    }
+]


### PR DESCRIPTION
In preparation for https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2957

The lists point to files in a repo of mine for now but will be transitioned to an SSWG controlled repo when done with testing.