### PR TITLE
Update upload/download artifacts to v4

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
           cp $(swift build --show-bin-path)/validator $GITHUB_WORKSPACE/
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: |
             validator
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifact
 
@@ -59,7 +59,7 @@ jobs:
             diff packages.json redirect-checked.json || true
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: |
             redirect-checked.json
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifact
 


### PR DESCRIPTION
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

> Starting November 30, 2024, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact). Customers should update workflows to begin using [v4 of the artifact actions](https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/) as soon as possible. While v4 of the artifact actions improves upload and download speeds by up to 98% and includes several new features, there are [key differences](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) from previous versions that may require updates to your workflows. Please see [the documentation](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) in the project repositories for guidance on how to migrate your workflows.