### PR TITLE
Add key

### DIFF
--- a/custom-package-collections.json
+++ b/custom-package-collections.json
@@ -1,17 +1,20 @@
 [
     {
+        "key": "sswg-graduated",
         "name": "SSWG Graduated",
         "description": "SSWG packages that are in 'graduated' state",
         "badge": "SSWG",
         "url": "https://raw.githubusercontent.com/finestructure/sswg-package-lists/refs/heads/main/graduated.json"
     },
     {
+        "key": "sswg-incubating",
         "name": "SSWG Incubating",
         "description": "SSWG packages that are in 'incubating' state",
         "badge": "SSWG",
         "url": "https://raw.githubusercontent.com/finestructure/sswg-package-lists/refs/heads/main/incubating.json"
     },
     {
+        "key": "sswg-sandbox",
         "name": "SSWG Sandbox",
         "description": "SSWG packages that are in 'sandbox' state",
         "badge": "SSWG",


### PR DESCRIPTION
This adds a `key` field to the custom collections, to serve two purposes:

- a unique id field that is used to look up and update custom collection records in our db
- a value that we can use as a slug in links to the collection

Currently, we're using `url` field to do these unique lookups but that's not great, because it's easily conceivable that a url will change. In fact, the SSWG urls will definitely change, because the lists will move out of my GH into the swift-server org. This would lead to new lists being added and us having to remove the existing lists. Not a huge deal but it's just better to have a unique key that's easily manageable.

(The lists still have an `id` field internally but that's just because `Fluent` creates that. We could probably use `key` instead but it's not worth the hassle to change this.)

We can then also use this field for the slug when linking to the collection:

https://staging.swiftpackageindex.com/collections/sswg-graduated

instead of

https://staging.swiftpackageindex.com/collections/SSWG%20graduated%20packages