### PR TITLE
Remove badge from custom collections

### DIFF
--- a/custom-package-collections.json
+++ b/custom-package-collections.json
@@ -3,21 +3,18 @@
         "key": "sswg-graduated",
         "name": "SSWG Graduated",
         "description": "SSWG packages that are in 'graduated' state",
-        "badge": "SSWG",
         "url": "https://raw.githubusercontent.com/finestructure/sswg-package-lists/refs/heads/main/graduated.json"
     },
     {
         "key": "sswg-incubating",
         "name": "SSWG Incubating",
         "description": "SSWG packages that are in 'incubating' state",
-        "badge": "SSWG",
         "url": "https://raw.githubusercontent.com/finestructure/sswg-package-lists/refs/heads/main/incubating.json"
     },
     {
         "key": "sswg-sandbox",
         "name": "SSWG Sandbox",
         "description": "SSWG packages that are in 'sandbox' state",
-        "badge": "SSWG",
         "url": "https://raw.githubusercontent.com/finestructure/sswg-package-lists/refs/heads/main/sandbox.json"
     }
 ]


### PR DESCRIPTION
Remove this key for now (it's optional in the model, so this won't require server changes) since we're not supporting custom SVG badges at this time.