### PR TITLE
Update to official SSWG urls

### DIFF
--- a/custom-package-collections.json
+++ b/custom-package-collections.json
@@ -4,20 +4,20 @@
         "name": "Graduated",
         "description": "SSWG packages that are in 'graduated' state",
         "badge": "SSWG",
-        "url": "https://raw.githubusercontent.com/finestructure/sswg-package-lists/refs/heads/main/graduated.json"
+        "url": "https://swift.org/api/v1/sswg/incubation/graduated.json"
     },
     {
         "key": "sswg-incubating",
         "name": "Incubating",
         "description": "SSWG packages that are in 'incubating' state",
         "badge": "SSWG",
-        "url": "https://raw.githubusercontent.com/finestructure/sswg-package-lists/refs/heads/main/incubating.json"
+        "url": "https://swift.org/api/v1/sswg/incubation/incubating.json"
     },
     {
         "key": "sswg-sandbox",
         "name": "Sandbox",
         "description": "SSWG packages that are in 'sandbox' state",
         "badge": "SSWG",
-        "url": "https://raw.githubusercontent.com/finestructure/sswg-package-lists/refs/heads/main/sandbox.json"
+        "url": "https://swift.org/api/v1/sswg/incubation/sandbox.json"
     }
 ]


### PR DESCRIPTION
I've confirmed that reconciliation works with these locally. We may want to smoke test these urls but the server project is probably not the right place for this.