### PR TITLE
Add NetworkMonitorKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6316,6 +6316,7 @@
   "https://github.com/rocxteady/WPSwift.git",
   "https://github.com/rogerluan/JSEN.git",
   "https://github.com/rogerluan/SwiftttCamera.git",
+  "https://github.com/Rohijulislam/NetworkMonitorKit.git",
   "https://github.com/romikabi/swift-access-macro.git",
   "https://github.com/romiroma/BroadcastWriter.git",
   "https://github.com/Romixery/SwiftStomp.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [NetworkMonitorKit](https://github.com/Rohijulislam/NetworkMonitorKit)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
