### PR TITLE
Remove non-existing AndyHeardApps repositories

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -460,8 +460,6 @@
   "https://github.com/andtie/YukonMatchedGeometry.git",
   "https://github.com/andybest/linenoise-swift.git",
   "https://github.com/andyfinnell/NativeMarkKit.git",
-  "https://github.com/AndyHeardApps/ErrorCode.git",
-  "https://github.com/AndyHeardApps/Revertible.git",
   "https://github.com/andymedvedev/CTXTutorialEngine.git",
   "https://github.com/angelopino/APJExtensions.git",
   "https://github.com/angu-software/SwiftAsyncAssert.git",


### PR DESCRIPTION
Packages by [AndyHeardApps](https://github.com/AndyHeardApps) are no longer available, so I'm removing them from the packages list. 

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
