### PR TITLE
Added nytimes/NYTPhotoViewer

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5446,6 +5446,7 @@
   "https://github.com/nyanko3141592/SwiftNGramWiithMarisaTrie.git",
   "https://github.com/nysander/twitter-text.git",
   "https://github.com/nysander/UnicodeURL.git",
+  "https://github.com/nytimes/NYTPhotoViewer.git",
   "https://github.com/nyxhub/PythonBridge.git",
   "https://github.com/nzrsky/TimeZoneIdentifier.git",
   "https://github.com/o-nnerb/navigation-kit.git",


### PR DESCRIPTION
`nytimes/NYTPhotoViewer` fails during PackageList validation with this error:

```json
{
  "message": "Although you appear to have the correct authorization credentials, the `nytimes` organization has an IP allow list enabled, and your IP address is not permitted to access this resource.",
  "documentation_url": "https://docs.github.com/rest/git/trees#get-a-tree",
  "status": "403"
}
```

However, the repo can be cloned without any issues so I think we should be fine in production once it's in the list, so I'm adding it manually. I'll monitor it going into the index once it's merged and check it's successful.