### PR TITLE
Replace use of deprecated output commands

### DIFF
--- a/.github/check_for_changes.sh
+++ b/.github/check_for_changes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $(git status --porcelain) ]]; then
-    echo '::set-output name=changes::true'
+    echo "changes=true" >> $GITHUB_OUTPUT
 else
-    echo '::set-output name=changes::false'
+    echo "changes=false" >> $GITHUB_OUTPUT
 fi

--- a/validate.swift
+++ b/validate.swift
@@ -512,7 +512,12 @@ do {
         print("ERROR: \(appError.localizedDescription)")
 
         if ProcessInfo.processInfo.environment["CI"] == "true" {
-            print("::set-output name=validateError::\(appError.localizedDescription)")
+            let output = "validateError=\(appError.localizedDescription)\n"
+            if let githubOutput = ProcessInfo.processInfo.environment["GITHUB_OUTPUT"] {
+                try? output.write(toFile: githubOutput, atomically: true, encoding: .utf8)
+            } else {
+                print(output)
+            }
 
             if case .packageListChanged = appError {
                 // For CI it's acceptable for the package list to change as we'll simply take the output of this script
@@ -521,7 +526,12 @@ do {
         }
     } else {
         if ProcessInfo.processInfo.environment["CI"] == "true" {
-            print("::set-output name=validateError::\(error)")
+            let output = "validateError=\(error)\n"
+            if let githubOutput = ProcessInfo.processInfo.environment["GITHUB_OUTPUT"] {
+                try? output.write(toFile: githubOutput, atomically: true, encoding: .utf8)
+            } else {
+                print(output)
+            }
         }
 
         print("ERROR: \(error)")


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

They have technically "postponed" the removal of the old solution, but warnings in logs so thought I'd try and fix them for yous.