### PR TITLE
Fix SPI_PROCESSING variable

### DIFF
--- a/validate.swift
+++ b/validate.swift
@@ -100,7 +100,7 @@ func shell(_ args: [String], at path: URL, returnStdOut: Bool = false, returnStd
     task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
     task.arguments = args
     task.currentDirectoryURL = path
-    task.environment = ["SPI_PROCESSING": "1"]
+    task.environment = ProcessInfo.processInfo.environment.merging(["SPI_PROCESSING": "1"], uniquingKeysWith: { $1 })
     let stdout = Pipe()
     let stderr = Pipe()
     if returnStdOut {


### PR DESCRIPTION
On Linux, assigning to `task.environment` without preserving existing values resets it completely and pretty much breaks everything 😕