### PR TITLE
Adds Blend

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1683,6 +1683,7 @@
   "https://github.com/contentstack/contentstack-swift.git",
   "https://github.com/contentstack/contentstack-utils-swift.git",
   "https://github.com/context-sdk/context-sdk-releases.git",
+  "https://github.com/convenience-init/Blend.git",
   "https://github.com/coodly/talktocloud.git",
   "https://github.com/CooperCorona/COpenBlas.git",
   "https://github.com/CooperCorona/CoronaErrors.git",
@@ -9437,6 +9438,5 @@
   "https://github.com/zunda-pixel/tripadvisor-swift.git",
   "https://github.com/zvonicek/ImageSlideshow.git",
   "https://github.com/zweigraf/fakebundle.git",
-  "https://github.com/zxcj04/WMSKit.git",
-  "https://github.com/convenience-init/Blend.git"
+  "https://github.com/zxcj04/WMSKit.git"
 ]


### PR DESCRIPTION
The package(s) being submitted are:

* [Blend](https://github.com/convenience-init/Blend)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
