### PR TITLE
Update README.md link to DocC build pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There are a few requirements for inclusion in the index, but they aren't onerous
 
 > **Note:** Our build system can now generate and host DocC documentation and make it available from your package’s page in the index. All we need is a little configuration data so that we know how best to build your docs.
 >
-> [More information here](https://blog.swiftpackageindex.com/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation/).
+> [More information here](https://swiftpackageindex.com/SwiftPackageIndex/SPIManifest/documentation/spimanifest/commonusecases).
 
 > **Note:** If submitting your own packages, don't forget to add shields.io badges to your package's README to always have up to date swift version and platform compatibility information readily available. Once your package appears in the index, use the "Do you maintain this package?" link in the right-hand sidebar of your package page and use the provided markdown.
 >


### PR DESCRIPTION
The README link pointed to the old page that contains a notice to the new page at the top :)