### PR TITLE
Add ExtendedSwiftMath package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1567,6 +1567,7 @@
   "https://github.com/chriseidhof/commonmark-swift.git",
   "https://github.com/chriseidhof/pretty.git",
   "https://github.com/chriseidhof/TerminalUI.git",
+  "https://github.com/ChrisGVE/ExtendedSwiftMath.git",
   "https://github.com/ChrisGVE/LuaSwift.git",
   "https://github.com/ChrisGVE/MarkdownExtendedView.git",
   "https://github.com/chrisladd/DashDashSwift.git",


### PR DESCRIPTION
[38;2;127;132;156m   1[0m [38;2;205;214;244m## Package Information[0m
[38;2;127;132;156m   2[0m 
[38;2;127;132;156m   3[0m [38;2;205;214;244m**Repository:** https://github.com/ChrisGVE/ExtendedSwiftMath[0m
[38;2;127;132;156m   4[0m 
[38;2;127;132;156m   5[0m [38;2;205;214;244m**Description:** ExtendedSwiftMath is a fork of [SwiftMath](https://github.com/mgriebling/SwiftMath) that extends LaTeX mathematical symbol coverage. It addresses gaps identified through a comprehensive analysis against the OEIS LaTeX mathematical symbols reference.[0m
[38;2;127;132;156m   6[0m 
[38;2;127;132;156m   7[0m [38;2;205;214;244m**Features:**[0m
[38;2;127;132;156m   8[0m [38;2;205;214;244m- Drop-in replacement for SwiftMath (same product name)[0m
[38;2;127;132;156m   9[0m [38;2;205;214;244m- Planned additions: blackboard bold (`\mathbb{}`), delimiter sizing (`\big`, `\Big`, `\bigg`, `\Bigg`), negated relations (amssymb equivalents), and 50+ missing symbol mappings[0m
[38;2;127;132;156m  10[0m 
[38;2;127;132;156m  11[0m [38;2;205;214;244m**License:** MIT (same as upstream SwiftMath)[0m
[38;2;127;132;156m  12[0m 
[38;2;127;132;156m  13[0m [38;2;205;214;244m**Platforms:** iOS 11+, macOS 12+[0m