### PR TITLE
Add ChrisGVE/thales

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1569,6 +1569,7 @@
   "https://github.com/ChrisGVE/ExtendedSwiftMath.git",
   "https://github.com/ChrisGVE/LuaSwift.git",
   "https://github.com/ChrisGVE/MarkdownExtendedView.git",
+  "https://github.com/ChrisGVE/thales.git",
   "https://github.com/chrisladd/DashDashSwift.git",
   "https://github.com/ChrisMash/AlertPresenter.git",
   "https://github.com/ChrisMash/ProvisioningProfile.git",


### PR DESCRIPTION
Add [thales](https://github.com/ChrisGVE/thales) - A Swift-compatible computer algebra system library.

thales is a Rust library that provides symbolic mathematics operations including:
- Equation solving (linear, quadratic, polynomial, systems)
- Calculus operations (derivatives, integrals, limits)
- Coordinate system transformations
- Complex number operations
- LaTeX parsing and rendering

The library includes Swift bindings with a clean, documented Swift API via SPM.