### PR TITLE
Update package name

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2242,7 +2242,7 @@
   "https://github.com/DenTelezhkin/DTCollectionViewManager.git",
   "https://github.com/DenTelezhkin/DTModelStorage.git",
   "https://github.com/DenTelezhkin/DTTableViewManager.git",
-  "https://github.com/DePasqualeOrg/mcp-swift-sdk.git",
+  "https://github.com/DePasqualeOrg/swift-mcp.git",
   "https://github.com/DePasqualeOrg/swift-docc-plugin.git",
   "https://github.com/DePasqualeOrg/swift-docc.git",
   "https://github.com/designatednerd/plister.git",


### PR DESCRIPTION
I've update my package name from mcp-swift-sdk to swift-mcp.