### PR TITLE
Add kevinnz/SSTV-MEL

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4594,6 +4594,7 @@
   "https://github.com/kevinhermawan/ViewCondition.git",
   "https://github.com/kevinhermawan/ViewState.git",
   "https://github.com/kevinmbeaulieu/star.git",
+  "https://github.com/kevinnz/SSTV-MEL.git",
   "https://github.com/KevinVitale/SwiftSDL.git",
   "https://github.com/kevinw/GodotVision.git",
   "https://github.com/kewlbear/BLAS-LAPACK-AppStore-Workaround.git",


### PR DESCRIPTION
Adding [SSTV-MEL](https://github.com/kevinnz/SSTV-MEL) — a Swift SSTV decoder library + CLI for decoding Slow-Scan Television audio (WAV) to images (PNG/JPEG). Supports PD120, PD180, and Robot36 modes.

- Swift Package Manager compatible
- macOS 13+ / iOS 16+
- Zero external dependencies
- MIT licensed