### PR TITLE
Add SwiftlyFeedbackKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -8753,6 +8753,7 @@
   "https://github.com/swiftysites/swiftysites.git",
   "https://github.com/SwiftyTesseract/libtesseract.git",
   "https://github.com/SwiftZip/SwiftZip.git",
+  "https://github.com/Swiftly-Developed/SwiftlyFeedbackKit.git",
   "https://github.com/swifweb/animate.git",
   "https://github.com/swifweb/autolayout.git",
   "https://github.com/swifweb/bootstrap.git",


### PR DESCRIPTION
 The package(s) being submitted are:                                                                                                                                                                                
                                                                                          
  * [SwiftlyFeedbackKit](https://github.com/Swiftly-Developed/SwiftlyFeedbackKit.git)                                                                                                                                
                                                                                                                                                                                                                     
  ## Checklist

  I have either:

  * [ ] Run `swift ./validate.swift`.

  Or, checked that:

  * [x] The package repositories are publicly accessible.
  * [x] The packages all contain a `Package.swift` file in the root folder.
  * [x] The packages are written in Swift 5.0 or later.
  * [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
  * [x] The packages all have at least one release tagged as a semantic version.
  * [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
  * [x] The packages all are fully specified including the protocol (usually `https`) and the `.git` extension.
  * [x] The packages all compile without errors.
  * [x] The package list JSON file is sorted alphabetically.