### PR TITLE
Add SwiftlyFeedbackKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -8654,6 +8654,7 @@
   "https://github.com/swiftlang/swift-tools-protocols.git",
   "https://github.com/swiftlang/swift-tools-support-core.git",
   "https://github.com/swiftlang/swiftly.git",
+  "https://github.com/Swiftly-Developed/SwiftlyFeedbackKit.git",
   "https://github.com/SwiftNIOExtras/swift-nio-irc.git",
   "https://github.com/SwiftNIOExtras/swift-nio-redis.git",
   "https://github.com/SwiftObjects/SwiftObjects.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [SwiftlyFeedbackKit](https://github.com/Swiftly-Developed/SwiftlyFeedbackKit.git)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.