### PR TITLE
Update alpozcan/yazman

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -467,7 +467,7 @@
   "https://github.com/alobaili/camera-picker.git",
   "https://github.com/Alpensegler/TweaKit.git",
   "https://github.com/Alpha-Coders/HTMLBuilder.git",
-  "https://github.com/alpozcan/muharrir.git",
+  "https://github.com/alpozcan/yazman.git",
   "https://github.com/alschmut/SwiftBuildableMacro.git",
   "https://github.com/alta/swift-opus.git",
   "https://github.com/AlTavares/Ciao.git",


### PR DESCRIPTION
Repository was renamed from `alpozcan/muharrir` to `alpozcan/yazman`. Updating the package URL accordingly.