### PR TITLE
Add swift-airgap

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3371,6 +3371,7 @@
   "https://github.com/garmin/connectiq-companion-app-sdk-ios.git",
   "https://github.com/garmin/fit-objective-c-sdk.git",
   "https://github.com/garriguv/SQLiteMigrationManager.swift.git",
+  "https://github.com/garry-jeromson/swift-airgap.git",
   "https://github.com/garynewby/HLSVideoCache.git",
   "https://github.com/garynewby/PianoKeyboard.git",
   "https://github.com/Gatada/JBits.git",


### PR DESCRIPTION
Add [swift-airgap](https://github.com/garry-jeromson/swift-airgap) — a Swift package that detects and fails any test that attempts a real HTTP/HTTPS network request.

- Drop-in, zero dependencies
- Supports both XCTest and Swift Testing
- Works on iOS, macOS, tvOS, and watchOS
- Swift 6 strict concurrency