### PR TITLE
Remove AsyncRecorder and InjectKit dependencies

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -8495,8 +8495,6 @@
   "https://github.com/starsite/SwiftFM.git",
   "https://github.com/stasel/WebRTC.git",
   "https://github.com/statsig-io/statsig-kit.git",
-  "https://github.com/StatusQuo/AsyncRecorder.git",
-  "https://github.com/StatusQuo/InjectKit.git",
   "https://github.com/std-swift/Encoding.git",
   "https://github.com/SteadyAction/DesignableView.git",
   "https://github.com/SteadyAction/EtherWalletKit.git",


### PR DESCRIPTION
Removed unused dependencies from packages.json

The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
