### PR TITLE
Add SwiftGrad

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -8761,6 +8761,8 @@
   "https://github.com/swift-tweets/tweetup-kit.git",
   "https://github.com/swift-vim/SwiftForVim.git",
   "https://github.com/swift-vim/swiftpackagemanager.vim.git",
+  "https://github.com/SwiftAutograd/SwiftGrad.git",
+  "https://github.com/SwiftAutograd/SwiftRL.git",
   "https://github.com/SwiftBeta/SwiftOpenAI.git",
   "https://github.com/SwiftBlocksUI/SwiftBlocksUI.git",
   "https://github.com/SwiftCommon/DataKit.git",


### PR DESCRIPTION
Add [SwiftGrad](https://github.com/SwiftAutograd/SwiftGrad) — a tiny autograd engine and neural network library in pure Swift, inspired by Karpathy's micrograd.

- Pure Swift, zero dependencies
- Reverse-mode automatic differentiation
- Neural network library (Neuron, Layer, MLP)
- MIT licensed
- Tagged release: 0.1.0