### PR TITLE
Add nsk-bci/mindwave-sdk-apple

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6549,6 +6549,7 @@
   "https://github.com/nshipster/passwordrules.git",
   "https://github.com/NSHipster/swift-log-github-actions.git",
   "https://github.com/NSHipster/SwiftSyntaxHighlighter.git",
+  "https://github.com/nsk-bci/mindwave-sdk-apple",
   "https://github.com/nslogmeng/swift-service.git",
   "https://github.com/nsomar/Guaka.git",
   "https://github.com/nssina/NSAsyncCachedImage.git",


### PR DESCRIPTION
Adding the NeuroSky MindWave SDK for Apple platforms (iOS 14+ / macOS 11+).

- BLE transport via CoreBluetooth
- BT Classic fallback via IOBluetooth (macOS)
- AsyncStream API (Swift concurrency)
- CI passing on macos-14