### PR TITLE
Add syncfield-swift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6705,6 +6705,7 @@
   "https://github.com/OpenCombine/OpenCombine.git",
   "https://github.com/OpenDive/OpenAIKit.git",
   "https://github.com/openfort-xyz/swift-sdk.git",
+  "https://github.com/OpenGraphLabs/syncfield-swift.git",
   "https://github.com/openid/AppAuth-iOS.git",
   "https://github.com/OpenKitten/Cheetah.git",
   "https://github.com/openkitten/cryptokitten.git",


### PR DESCRIPTION
Adding [syncfield-swift](https://github.com/OpenGraphLabs/syncfield-swift) — lightweight timestamp capture SDK for multi-stream synchronization on iOS/macOS.

- **Package URL:** https://github.com/OpenGraphLabs/syncfield-swift.git
- **License:** Apache-2.0
- **Platforms:** iOS 15+, macOS 12+
- **Dependencies:** None