### PR TITLE
Add AZDial dependency to packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -8734,6 +8734,7 @@
   "https://github.com/sufiyanyusuf/sockit.git",
   "https://github.com/sufiyanyusuf/SwiftTea.git",
   "https://github.com/SummaCristian/LocalizerKit.git",
+  "https://github.com/SumPositive/AZDial.git",
   "https://github.com/SumSubstance/IdensicMobileSDK-iOS-Core.git",
   "https://github.com/SumSubstance/IdensicMobileSDK-iOS.git",
   "https://github.com/sunghyun-k/stack-navigation.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Package Name](https://example.com/repository/)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.
