### PR TITLE
Add rontech-es/swift-openapi-mock

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -7710,7 +7710,7 @@
   "https://github.com/RonasIT/swift-networking.git",
   "https://github.com/Ronitsabhaya75/Luxe-UI.git",
   "https://github.com/ronstorm/tca-kit.git",
-  "https://github.com/rontech-es/swift-openapi-mock",
+  "https://github.com/rontech-es/swift-openapi-mock.git",
   "https://github.com/rootstrap/PagedLists.git",
   "https://github.com/rootstrap/RSSwiftNetworking.git",
   "https://github.com/rootstrap/SwiftGradients.git",


### PR DESCRIPTION
Adds `swift-openapi-mock` — a record/replay mock middleware for apps built with [swift-openapi-generator](https://github.com/apple/swift-openapi-generator).

It hooks into the `ClientMiddleware` layer and uses `operationID` as the match key, filling a gap that URLSession-level mocking libraries (OHHTTPStubs, Mocker, MockDuck) cannot address.

https://github.com/rontech-es/swift-openapi-mock