### PR TITLE
Add SwiftASB

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3524,6 +3524,7 @@
   "https://github.com/gaelic-ghost/mlx-audio-swift.git",
   "https://github.com/gaelic-ghost/SpeakSwiftly.git",
   "https://github.com/gaelic-ghost/SpeakSwiftlyServer.git",
+  "https://github.com/gaelic-ghost/SwiftASB.git",
   "https://github.com/gaelic-ghost/TextForSpeech.git",
   "https://github.com/gaetanomatonti/BottomSheet.git",
   "https://github.com/galileostudio/nyarudb2.git",


### PR DESCRIPTION
Adds SwiftASB to the Swift Package Index package list.\n\nPackage URL: https://github.com/gaelic-ghost/SwiftASB.git\n\nValidation:\n- swift validate.swift