### PR TITLE
Add EffectView dependency to packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1983,6 +1983,7 @@
   "https://github.com/Cosmo/Nodes.git",
   "https://github.com/Cosmo/StringCase.git",
   "https://github.com/cossacklabs/themis.git",
+  "https://github.com/couchdeveloper/EffectView.git",
   "https://github.com/coughski/ActionBuilder.git",
   "https://github.com/couriere/uiextensions.git",
   "https://github.com/coxijcake/CxjToasts.git",


### PR DESCRIPTION
A small SwiftUI helper for Elm-style event handling with explicit side effects.

The package(s) being submitted are:

[EffectView](https://github.com/couchdeveloper/EffectView.git)

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x ] The package repositories are publicly accessible.
* [ x] The packages all contain a `Package.swift` file in the root folder.
* [ x] The packages are written in Swift 5.0 or later.
* [ x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ x] The packages all compile without errors.
* [ x] The package list JSON file is sorted alphabetically.
