### PR TITLE
Add gsdali/OCCTSwift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3792,6 +3792,7 @@
   "https://github.com/grype/SwiftAnnouncements.git",
   "https://github.com/grype/SwiftBeacon.git",
   "https://github.com/gscalzo/SwiftCubicSpline.git",
+  "https://github.com/gsdali/OCCTSwift.git",
   "https://github.com/guillaumealgis/SimpleMDM-Swift.git",
   "https://github.com/guillermomuntaner/Burritos.git",
   "https://github.com/guinmoon/llmfarm_core.swift.git",


### PR DESCRIPTION
Adding [gsdali/OCCTSwift](https://github.com/gsdali/OCCTSwift) — a comprehensive Swift wrapper for OpenCASCADE Technology (OCCT) 8.0.0, providing B-Rep solid modeling for macOS, iOS, visionOS, and tvOS (arm64).

- License: LGPL-2.1
- SemVer-stable from [v1.0.0](https://github.com/gsdali/OCCTSwift/releases/tag/v1.0.0); current release [v1.0.1](https://github.com/gsdali/OCCTSwift/releases/tag/v1.0.1)
- `Package.swift` ships a binary target (pre-built OCCT.xcframework, 341 MB, attached to the v1.0.0 GitHub release with a verified SHA256 checksum)
- `.spi.yml` declares macOS / iOS builders across Swift 6.0–6.3 with DocC docs target

Inserted at the correct alphabetical position between `gscalzo/SwiftCubicSpline.git` and `guillaumealgis/SimpleMDM-Swift.git`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)