### PR TITLE
Add gsdali/OCCTMCP

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3792,6 +3792,7 @@
   "https://github.com/grype/SwiftAnnouncements.git",
   "https://github.com/grype/SwiftBeacon.git",
   "https://github.com/gscalzo/SwiftCubicSpline.git",
+  "https://github.com/gsdali/OCCTMCP.git",
   "https://github.com/guillaumealgis/SimpleMDM-Swift.git",
   "https://github.com/guillermomuntaner/Burritos.git",
   "https://github.com/guinmoon/llmfarm_core.swift.git",


### PR DESCRIPTION
Adds [gsdali/OCCTMCP](https://github.com/gsdali/OCCTMCP) — an MCP server that gives LLMs the ability to author, inspect, and iterate on 3D CAD models with OpenCASCADE via the OCCTSwift family. 49 typed MCP tools (authoring, scene reads, mutation, introspection, construction, analysis, selection / remap, annotations / overlays, I/O, mesh, drawing, topology graph), in-process against OCCTSwift / OCCTSwiftMesh / OCCTSwiftScripts / OCCTSwiftTools / OCCTSwiftAIS / OCCTSwiftViewport.

### Checklist

- [x] Publicly accessible — https://github.com/gsdali/OCCTMCP
- [x] Valid `Package.swift` in the repo root
- [x] Written in Swift 6.1 (toolchain `// swift-tools-version: 6.1`)
- [x] Tagged semantic version — `v1.0.0` https://github.com/gsdali/OCCTMCP/releases/tag/v1.0.0
- [x] `swift package dump-package` produces valid JSON (verified locally on the v1.0.0 tag)
- [x] URL includes `https` and `.git` extension
- [x] Compiles without errors (`swift build`) and `swift test` is 22/22 green
- [x] LGPL-2.1-or-later license — same as OCCTSwift
- [x] `.spi.yml` provided for DocC rendering of the `OCCTMCPCore` library on macOS

### Notes

- Platform: macOS 15+ only (the OCCT.xcframework arm64 platform — OCCTSwift is the dependency that imposes the floor)
- Target audience: CAD-tooling builders who want to expose OCCT to LLMs over MCP