### PR TITLE
Add john-rocky/PrivateFoundationModels

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4572,6 +4572,7 @@
   "https://github.com/john-mueller/Hyphenation.git",
   "https://github.com/john-mueller/HyphenationPublishPlugin.git",
   "https://github.com/john-mueller/TidyHTMLPublishStep.git",
+  "https://github.com/john-rocky/PrivateFoundationModels.git",
   "https://github.com/john-rocky/SemanticImage.git",
   "https://github.com/johnbona/disque.git",
   "https://github.com/JohnEstropia/CoreStore.git",


### PR DESCRIPTION
Adding `john-rocky/PrivateFoundationModels` — a Swift package that mirrors Apple's `FoundationModels` API on iOS 18+ with pluggable backends.

- Repo: https://github.com/john-rocky/PrivateFoundationModels
- Tagged releases: v0.1.0 through v0.4.0
- Tests: 90/90 passing on CI (macos-15, latest-stable Xcode)
- `swift package dump-package` validated by the PackageList validator (output above)

The package lets developers write code against Apple's `LanguageModelSession.respond(...)` shape and run it on iOS 18 (CoreML/MLX backends) or iOS 26+ (native FoundationModels passthrough).

Author: Daisuke Majima (@john-rocky) — maintainer of CoreML-Models, CoreML-LLM, and the mlboydaisuke HuggingFace model collection.