### PR TITLE
Add mlilback/LibmobiSPM

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6224,7 +6224,7 @@
   "https://github.com/ml-explore/mlx-swift.git",
   "https://github.com/ml-opensource/KeyboardHelper.git",
   "https://github.com/ml-opensource/Rye.git",
-  "https://github.com/mlilback/LibmobiSPM",
+  "https://github.com/mlilback/LibmobiSPM.git",
   "https://github.com/MLSDev/LoadableViews.git",
   "https://github.com/MLSDev/TRON.git",
   "https://github.com/mmellau/swift-beacon.git",

--- a/packages.json
+++ b/packages.json
@@ -6224,6 +6224,7 @@
   "https://github.com/ml-explore/mlx-swift.git",
   "https://github.com/ml-opensource/KeyboardHelper.git",
   "https://github.com/ml-opensource/Rye.git",
+  "https://github.com/mlilback/LibmobiSPM",
   "https://github.com/MLSDev/LoadableViews.git",
   "https://github.com/MLSDev/TRON.git",
   "https://github.com/mmellau/swift-beacon.git",


### PR DESCRIPTION
Adds [mlilback/LibmobiSPM](https://github.com/mlilback/LibmobiSPM) — a Swift Package Manager wrapper for [libmobi](https://github.com/bfabiszewski/libmobi) v0.9.

**What it provides:** A `CLibmobi` C target that lets Swift apps read MOBI and AZW3 (KF8) ebook files on macOS and iOS/iPadOS without any external dependencies. Uses libmobi's bundled miniz and internal xmlwriter.

**Why it's useful:** No SPM wrapper for libmobi currently exists. Several commercial App Store apps already ship libmobi; this makes it easy to add via SPM.

**License:** MIT wrapper around LGPL v3 libmobi sources. Compiles clean on macOS (arm64, x86_64) and iOS (arm64).