### PR TITLE
Add ethora-sdk-swift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2274,6 +2274,7 @@
   "https://github.com/danthorpe/swift-utilities.git",
   "https://github.com/danwood/SwiftUICoreImage.git",
   "https://github.com/dapperstout/swift-bytes.git",
+  "https://github.com/dappros/ethora-sdk-swift.git",
   "https://github.com/daprice/BlurHashViews.git",
   "https://github.com/daprice/iOS-Tactile-Slider.git",
   "https://github.com/daprice/SwiftKMeansPlusPlus.git",


### PR DESCRIPTION
Adds [`ethora-sdk-swift`](https://github.com/dappros/ethora-sdk-swift) — the official Swift SDK for [Ethora](https://github.com/dappros/ethora), an open-source XMPP-based chat & messaging platform. Ships two products: `XMPPChatCore` (auth, REST API, XMPP transport, stores, messaging) and `XMPPChatUI` (ready-made SwiftUI chat UI on top of the core).

- Public repo: yes
- `Package.swift` at root: yes (`swift-tools-version: 5.9`, iOS 15+)
- License: Apache-2.0
- Latest tag: [`v1.0.0`](https://github.com/dappros/ethora-sdk-swift/releases/tag/v1.0.0) (semver)
- URL: `https://github.com/dappros/ethora-sdk-swift.git`

Inserted alphabetically.