### PR TITLE
Add pintaste/swift-llm

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -7372,6 +7372,7 @@
   "https://github.com/PimCoumans/DidUpdate.git",
   "https://github.com/PimCoumans/PanelPresenter.git",
   "https://github.com/pinguard/pinguard-ios.git",
+  "https://github.com/pintaste/swift-llm.git",
   "https://github.com/pinterest/PINCache.git",
   "https://github.com/pinterest/PINOperation.git",
   "https://github.com/pinterest/PINRemoteImage.git",


### PR DESCRIPTION
Adding swift-llm — a native Swift Package for Claude and OpenAI with async/await, streaming, and zero dependencies. Supports macOS 12+ and iOS 15+.