### PR TITLE
Add lintuxt/swift-cli-kit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5401,6 +5401,7 @@
   "https://github.com/linhay/EmptyPage.git",
   "https://github.com/linhay/SectionKit.git",
   "https://github.com/linhay/Stem.git",
+  "https://github.com/lintuxt/swift-cli-kit.git",
   "https://github.com/LinusSkucas/ShortcutsKit.git",
   "https://github.com/LinusU/JSBridge.git",
   "https://github.com/LinusU/Marionette.git",


### PR DESCRIPTION
Adding [lintuxt/swift-cli-kit](https://github.com/lintuxt/swift-cli-kit) — a Swift library, scaffold, and conventions for native macOS command-line tools.

- **Repo:** https://github.com/lintuxt/swift-cli-kit
- **License:** MIT
- **Latest tag:** v0.1.1
- **Swift:** 6.0+
- **Platform:** macOS 13+
- **Used by:** [lintuxt/solcito](https://github.com/lintuxt/solcito), [lintuxt/displayswitcher](https://github.com/lintuxt/displayswitcher)

Inserted in alphabetical position between `linhay/Stem.git` and `LinusSkucas/ShortcutsKit.git`.