### PR TITLE
Add SwiftSnapshotDocumentation

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -8318,6 +8318,7 @@
   "https://github.com/SAP/cloud-sdk-ios-fiori.git",
   "https://github.com/SAP/cloud-sdk-ios.git",
   "https://github.com/sardon/GraduatedSlider.git",
+  "https://github.com/sasha-riabchuk/SwiftSnapshotDocumentation.git",
   "https://github.com/satanwoo/wzqinstantsearch.git",
   "https://github.com/satoshi-takano/OpenGraph.git",
   "https://github.com/SaudAlhafith/WeekScheduleView.git",


### PR DESCRIPTION
Adding [SwiftSnapshotDocumentation](https://github.com/sasha-riabchuk/SwiftSnapshotDocumentation), a Swift package that generates DocC documentation from SwiftUI screens with automatic snapshot testing across devices and themes.

- Public repository with a valid `Package.swift` at the root
- Provides a library product (`SwiftSnapshotDocumentation`)
- Tagged with a SemVer release (`1.0.0`)
- Platforms: iOS 17+, macOS 14+; Swift 5.9+

The URL has been added to `packages.json` in the correct case-insensitive sort position.