### PR TITLE
Add WindowPopupKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -9812,6 +9812,7 @@
   "https://github.com/ThrottleCode/DragoDateTimePicker.git",
   "https://github.com/ThrottleCode/DragoTextField.git",
   "https://github.com/thumbtack/star.git",
+  "https://github.com/thuyetngocluong/WindowPopupKit.git",
   "https://github.com/Tibimac/GoogleSignInKit.git",
   "https://github.com/TICESoftware/vapor-gorush.git",
   "https://github.com/tichise/chatgpt-ui.git",


### PR DESCRIPTION
Adds [WindowPopupKit](https://github.com/thuyetngocluong/WindowPopupKit) — window-based popups for SwiftUI & UIKit you can `await` for a result (toast / popup / sheet / loading / full-screen presets), presentable from anywhere, with zero third-party dependencies.

- Public repo with a valid `Package.swift` and a library product (`WindowPopupKit`)
- Tagged release: `1.0.0`
- iOS 16+, Swift tools 6.0 (compiles in Swift 5 language mode)
- MIT licensed