### PR TITLE
Add SafeMediaKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -8370,6 +8370,7 @@
   "https://github.com/SAP/cloud-sdk-ios-fiori.git",
   "https://github.com/SAP/cloud-sdk-ios.git",
   "https://github.com/sardon/GraduatedSlider.git",
+  "https://github.com/SardorbekR/SafeMediaKit.git",
   "https://github.com/sasha-riabchuk/SwiftSnapshotDocumentation.git",
   "https://github.com/satanwoo/wzqinstantsearch.git",
   "https://github.com/satoshi-takano/OpenGraph.git",


### PR DESCRIPTION
Adds SafeMediaKit — a sensitive media intervention toolkit for Apple apps. It wraps Apple's SensitiveContentAnalysis framework with a policy engine, verdict caching, and drop-in SwiftUI/UIKit blur/reveal/block/report components with a customizable overlay.

- Repository: https://github.com/SardorbekR/SafeMediaKit
- License: MIT
- Releases: 0.1.0, 0.2.0
- Platforms: iOS 17+, macOS 14+, Mac Catalyst 17+ (Apple-only by design)