### PR TITLE
Add mi11ione/iris

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6137,6 +6137,7 @@
   "https://github.com/mhdhejazi/Dynamic.git",
   "https://github.com/mhennemeyer/singlepagescanner.git",
   "https://github.com/mhennemeyer/swift-toolbox.git",
+  "https://github.com/mi11ione/iris.git",
   "https://github.com/mi11ione/OpenGlass.git",
   "https://github.com/mi12labs/SwiftAI.git",
   "https://github.com/MiaKoring/SlashCommands.git",


### PR DESCRIPTION
Adds https://github.com/mi11ione/iris — a pure-Swift ARM64/ARM64E disassembler (library + CLI), Apache-2.0, tagged 0.1.0, builds with SwiftPM on macOS and Linux.