### PR TITLE
Add SwiftMeshHeal

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3910,6 +3910,7 @@
   "https://github.com/gsdali/OCCTSwiftTools.git",
   "https://github.com/gsdali/OCCTSwiftViewport.git",
   "https://github.com/gsdali/swift-sdk.git",
+  "https://github.com/gsdali/SwiftMeshHeal.git",
   "https://github.com/Guild-Ads/guild-ads-ios.git",
   "https://github.com/guillaumealgis/SimpleMDM-Swift.git",
   "https://github.com/guillermomuntaner/Burritos.git",


### PR DESCRIPTION
Adds [SwiftMeshHeal](https://github.com/gsdali/SwiftMeshHeal) — a dependency-free, pure-Swift on-device triangle-mesh healing library (Liepa minimum-dihedral hole filling, opening-aware selective fill, non-manifold resolution). MIT licensed, SemVer tags (v0.1.0, v0.1.1), DocC documentation, tests pass.