### PR TITLE
Add SwiftFirmataClient

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2735,6 +2735,7 @@
   "https://github.com/DominikHorn/ASN1Parser.git",
   "https://github.com/dongzs0907/MGUtils.git",
   "https://github.com/doordash-oss/swiftui-preview-snapshots.git",
+  "https://github.com/doraorak/SwiftFirmataClient.git",
   "https://github.com/dotaeva/scaffolding.git",
   "https://github.com/dotnet/signalr-client-swift.git",
   "https://github.com/dotsquares395/EmailValidationSPM.git",


### PR DESCRIPTION
Adds [SwiftFirmataClient](https://github.com/doraorak/SwiftFirmataClient) — a concurrency-safe Firmata client for Swift (control Arduino/ESP32 over Bonjour/TCP or BLE).

- Public repo with a library product and an MIT license
- Semantic-version releases (latest: `1.1.0`)
- Builds with Swift 6 (macOS 13+, iOS 16+)
- Includes a DocC documentation catalog