### PR TITLE
Add SwiftChessTools

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -10062,6 +10062,7 @@
   "https://github.com/tree-sitter/tree-sitter.git",
   "https://github.com/tribalworldwidelondon/CassowarySwift.git",
   "https://github.com/tribalworldwidelondon/PDFAuthor.git",
+  "https://github.com/Trickfest/SwiftChessTools.git",
   "https://github.com/tridiak/SpellSPM.git",
   "https://github.com/trifork/TIM-iOS.git",
   "https://github.com/trifork/TIMEncryptedStorage-iOS.git",


### PR DESCRIPTION
Adds SwiftChessTools to the Swift Package Index.

Package URL: https://github.com/Trickfest/SwiftChessTools.git
Latest release intended for indexing: 1.0.2

Validation run locally:
- ./validate.swift https://github.com/Trickfest/SwiftChessTools
- ./validate.swift