### PR TITLE
Add smbcloudXYZ/smbcloud-auth-swift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -8890,6 +8890,7 @@
   "https://github.com/smartdevicelink/bson_c_lib.git",
   "https://github.com/smartdevicelink/sdl_ios.git",
   "https://github.com/smartlook/analytics-swift-package.git",
+  "https://github.com/smbcloudXYZ/smbcloud-auth-swift.git",
   "https://github.com/smithy-lang/smithy-swift.git",
   "https://github.com/smud/ciconv.git",
   "https://github.com/smumriak/AppKid.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [smbcloud-auth-swift](https://github.com/smbcloudXYZ/smbcloud-auth-swift) — native Swift SDK for smbCloud Auth (`AuthCore` headless engine + `SmbCloudAuth` Apple UI layer).

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (`AuthCore`, `SmbCloudAuth` libraries) usable in other Swift apps.
* [x] The packages all have at least one release tagged as a semantic version (v1.0.0, v1.0.1).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (`https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.