### PR TITLE
Add adamtheturtle/PaginatedRESTClient

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -237,6 +237,7 @@
   "https://github.com/adamnemecek/webmidikit.git",
   "https://github.com/adamrushy/OpenAISwift.git",
   "https://github.com/adamtheturtle/CommandPaletteKit.git",
+  "https://github.com/adamtheturtle/PaginatedRESTClient.git",
   "https://github.com/adamwatters/SwiftGodot.git",
   "https://github.com/adamwatters/SwiftGodotKit.git",
   "https://github.com/adamwulf/ClippingBezier.git",


### PR DESCRIPTION
Adds [PaginatedRESTClient](https://github.com/adamtheturtle/PaginatedRESTClient) — a pluggable, dependency-free Swift paginator for bearer-authenticated REST APIs.

- Foundation-only core (no third-party dependencies), Linux-clean.
- Pluggable `RESTTransport` networking backend, with `URLSessionTransport` as the default.
- Library product `PaginatedRESTClient`, swift-tools-version 6.2.
- Tagged release: `0.1.0`.
- CI builds and tests on macOS and Linux.

The entry is inserted in case-insensitive alphabetical order and the list validates (valid JSON, sorted, no duplicates).