### PR TITLE
Add ManifoldKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5805,6 +5805,7 @@
   "https://github.com/MalkarovPark/IndustrialKit.git",
   "https://github.com/manasv/Updeto.git",
   "https://github.com/mangoumbrella/SwiftTitleCase.git",
+  "https://github.com/ManifoldKit/ManifoldKit.git",
   "https://github.com/maniramezan/SwiftyShell.git",
   "https://github.com/maniramezan/URLMacro.git",
   "https://github.com/maniramezan/UserDefaultMacro.git",


### PR DESCRIPTION
Adds [`ManifoldKit`](https://github.com/ManifoldKit/ManifoldKit) — a full-stack, multi-backend AI chat framework for Apple platforms (iOS 18+ / macOS 15+, Swift 6). One umbrella package provides a SwiftUI `ChatView`, the `ConversationRuntime` turn loop, SwiftData persistence, model-management UI, and inference backends across on-device (MLX, llama.cpp, Apple Foundation Models) and cloud (OpenAI, Anthropic, Ollama).

- Public, MIT-licensed, builds with SwiftPM.
- Has a `.spi.yml` declaring the documentation targets for DocC generation.
- Single-line addition, inserted in case-insensitive sorted order; `packages.json` remains valid, sorted, and duplicate-free.