### PR TITLE
Add expys-swift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -10319,6 +10319,7 @@
   "https://github.com/utahiosmac/Marshal.git",
   "https://github.com/UtiqTech/ios-sdk.git",
   "https://github.com/utmapp/VisionKeyboardKit.git",
+  "https://github.com/Utopia-Members-Club-Inc/expys-swift.git",
   "https://github.com/uuid25/swift-uuid25.git",
   "https://github.com/uxcam/uxcam-ios-sdk.git",
   "https://github.com/uxcam/uxcam-ios-swiftui.git",


### PR DESCRIPTION
Adds the official **Expys SDK for Swift** — https://github.com/Utopia-Members-Club-Inc/expys-swift

- Public repo, SwiftPM package (`Package.swift` at root), released tag `0.1.0`
- Foundation-only, async/await; supports iOS 15+ / macOS 12+
- Also distributed via CocoaPods (`ExpysSDK`)