### PR TITLE
Add NeumorphicUIKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -158,6 +158,7 @@
   "https://github.com/8rightside/Resistance.git",
   "https://github.com/9alvaro0/Pry.git",
   "https://github.com/9uiLe/swift-tasking.git",
+  "https://github.com/A-bv/NeumorphicUIKit.git",
   "https://github.com/a-sarris/KMBFormatter.git",
   "https://github.com/a2/MessagePack.swift.git",
   "https://github.com/a2/swift-shortcuts.git",


### PR DESCRIPTION
Adds [NeumorphicUIKit](https://github.com/A-bv/NeumorphicUIKit) — soft neumorphic depth for any UIKit view, palette-agnostic with automatic light/dark, iOS 15+.

- Public repo, valid `Package.swift`, Swift 5.9
- Library product `NeumorphicUIKit`
- Latest release: `3.2.1`
- `swift package dump-package` outputs valid JSON; builds and tests pass in CI