### PR TITLE
Add FoundationRadar

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6631,6 +6631,7 @@
   "https://github.com/NachoSoto/AsyncImageView.git",
   "https://github.com/naftaly/Footprint.git",
   "https://github.com/naftaly/Threadcrumb.git",
+  "https://github.com/NagaYu/FoundationRadar.git",
   "https://github.com/naithar/magickwand.git",
   "https://github.com/nakajima/HueEntertainmentSwift.git",
   "https://github.com/nakajima/LilHTML.git",


### PR DESCRIPTION
Adds [FoundationRadar](https://github.com/NagaYu/FoundationRadar) — a zero-dependency Swift package that measures the actual, current capability of Apple's Foundation Models stack on the device it runs on (availability, runtime-measured context size, opt-in latency micro-benchmark, Private Cloud Compute signals), with a local JSON capability history and shareable Markdown/JSON reports.

- Public repository with `Package.swift` at the root, MIT licensed
- Semantic version tag: `v0.1.0`
- `swift package dump-package` produces valid JSON (Swift 6.1 tools)
- `swift validate.swift` (package-list mode) passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)