### PR TITLE
Add elmulator

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -7831,6 +7831,7 @@
   "https://github.com/q-mobile/qgrid.git",
   "https://github.com/q231950/commands.git",
   "https://github.com/Q42/ValidationKit.git",
+  "https://github.com/qadanm/elmulator.git",
   "https://github.com/qata/recombine.git",
   "https://github.com/qawolf/WebDriverAgent.git",
   "https://github.com/QiuZhiFei/swift-commands.git",


### PR DESCRIPTION
Adds [elmulator](https://github.com/qadanm/elmulator) — a scriptable Bluetooth LE + TCP OBD2 (ELM327) adapter emulator and CI test harness. SwiftPM package at repo root with library products (Elmulator, ElmulatorTCP, ElmulatorBLE, ElmulatorBLETestSupport, ElmulatorCoreBluetoothMock) plus executables. Tagged v0.1.0, MIT-licensed, CI green.