### PR TITLE
Add Ritsurin

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5291,6 +5291,7 @@
   "https://github.com/koher/SwiftyAlgebra.git",
   "https://github.com/koher/swiftytopology.git",
   "https://github.com/koher/swiftyvector.git",
+  "https://github.com/KoichiroKAMADA/Ritsurin.git",
   "https://github.com/KoichiroKAMADA/Yashima.git",
   "https://github.com/Kolos65/Mockable.git",
   "https://github.com/kongzii/LoggerKit.git",


### PR DESCRIPTION
Adds Ritsurin to the package list.\n\nPackage URL: https://github.com/KoichiroKAMADA/Ritsurin.git\n\nValidation performed before submission:\n- Repository is public.\n- Root Package.swift is present.\n- Semantic version tag 0.1.0 is published.\n- `swift package dump-package` succeeds.\n- `swift build --target Ritsurin` succeeds.\n- `packages.json` validates with `jq empty`.