### PR TITLE
Add john-rocky/coreai-kit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4747,6 +4747,7 @@
   "https://github.com/john-mueller/Hyphenation.git",
   "https://github.com/john-mueller/HyphenationPublishPlugin.git",
   "https://github.com/john-mueller/TidyHTMLPublishStep.git",
+  "https://github.com/john-rocky/coreai-kit.git",
   "https://github.com/john-rocky/CoreML-LLM.git",
   "https://github.com/john-rocky/PrivateFoundationModels.git",
   "https://github.com/john-rocky/SemanticImage.git",


### PR DESCRIPTION
Adds [CoreAIKit](https://github.com/john-rocky/coreai-kit) — build LLM / VLM / ASR / TTS and more on Apple's Core AI framework (macOS/iOS 27) in a few lines of Swift. 49 models from the Core AI model zoo, downloadable and pinned to verified revisions.

- [x] Package.swift in the default branch
- [x] Tagged releases (0.1.0, 0.2.0 — SemVer)
- [x] Builds on macOS (CI: build + tests on every push)
- [x] BSD-3-Clause license