### PR TITLE
Add KassiOS

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -10406,6 +10406,7 @@
   "https://github.com/vaddieg/cometblue.git",
   "https://github.com/vadimkrutovlv/swift-data-helpers.git",
   "https://github.com/vadimkrutovlv/swift-network-request.git",
+  "https://github.com/VadimToptunov/KassiOS.git",
   "https://github.com/vadymmarkov/Fakery.git",
   "https://github.com/vadymmarkov/rexy.git",
   "https://github.com/vadymmarkov/When.git",


### PR DESCRIPTION
Adds [KassiOS](https://github.com/VadimToptunov/KassiOS) — a tiny, zero-dependency Kaspresso-style DSL over XCUITest (screen objects, implicit waits, flaky-safety). MIT, tagged releases up to 0.9.0, valid `Package.swift`. Inserted into `packages.json` in case-insensitive sorted order (one line).