### PR TITLE
Add iperf-swift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3774,6 +3774,7 @@
   "https://github.com/GetStream/stream-video-swift.git",
   "https://github.com/GettEngineering/Prism.git",
   "https://github.com/getyourguide/spmgraph.git",
+  "https://github.com/gewill/iperf-swift.git",
   "https://github.com/ggml-org/ggml.git",
   "https://github.com/ggml-org/llama.cpp.git",
   "https://github.com/ggruen/CloudKitSyncMonitor.git",


### PR DESCRIPTION
Adds the public Swift package:

https://github.com/gewill/iperf-swift.git

Validated with the repository's `validate.swift` script.