### PR TITLE
Add SwiftBIP39 package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2575,6 +2575,7 @@
   "https://github.com/devandsev/JustSignals.git",
   "https://github.com/devandsev/TapticKit.git",
   "https://github.com/DevCycleHQ/ios-client-sdk.git",
+  "https://github.com/devdasx/swift-bip39-mnemonic.git",
   "https://github.com/devedbox/commander.git",
   "https://github.com/developerinsider/spmdeveloperinsider.git",
   "https://github.com/deveronuas/GeoJSONSwiftHelper.git",


### PR DESCRIPTION
Adds https://github.com/devdasx/swift-bip39-mnemonic.git to the Swift Package Index package list.\n\nSource of truth: the public GitHub repository and release tags.