### PR TITLE
Add ai-university-aiu/causalontology

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -350,6 +350,7 @@
   "https://github.com/Ahmed-Ali/MacroSyn.git",
   "https://github.com/ahti/SQLele.git",
   "https://github.com/ahti/SQLeleCoder.git",
+  "https://github.com/ai-university-aiu/causalontology.git",
   "https://github.com/aidantwoods/swift-paseto.git",
   "https://github.com/aidantwoods/swift-sodium.git",
   "https://github.com/aidantwoods/TypedJSON.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [causalontology](https://github.com/ai-university-aiu/causalontology.git) — the Swift binding of Causalontology, a programming-language-neutral standard for reified causation (passes all 107 frozen conformance vectors).

## Checklist

I have either:

* [ ] Run `swift ./validate.swift`. _(No Swift toolchain on the submission machine; the equivalent JSON-validity, case-insensitive-sort, duplicate, and `https`+`.git` checks were run locally, and this PR’s `validate` CI runs `validate.swift` itself.)_

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later. _(swift-tools-version 5.9)_
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps. _(a `.library` product named `Causalontology`)_
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/). _(`v1.0.0`, `v1.0.1`, `v1.0.2`, `v2.0.0`)_
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically. _(inserted between `ahti/SQLeleCoder.git` and `aidantwoods/swift-paseto.git`; one line added; file remains valid JSON with no duplicates)_