### PR TITLE
Add llmkit-swift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -422,6 +422,7 @@
   "https://github.com/aksamitsah/CoreAnimator.git",
   "https://github.com/aksamitsah/CountryPickerAKS.git",
   "https://github.com/aksamitsah/DropDown.git",
+  "https://github.com/aktagon/llmkit-swift.git",
   "https://github.com/akvilary/mio.git",
   "https://github.com/akvilary/swift-huminize.git",
   "https://github.com/Al00X/LanguageDetector.git",


### PR DESCRIPTION
Adds https://github.com/aktagon/llmkit-swift.git

llmkit is a unified, typed LLM client for Swift: one API across Anthropic, OpenAI, Google, AWS Bedrock, and 30+ other model providers (chat, streaming, tool calling, image/video/music/speech generation, transcription). Built on Foundation and URLSession with no third-party dependencies; Apple platforms, Swift 5.9+. Released at v1.0.1 with SemVer tags.