### PR TITLE
Add Kiosk

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3038,6 +3038,7 @@
   "https://github.com/elgatosf/streamdeck-kit-macros.git",
   "https://github.com/eligutovsky/SyntacticSugar.git",
   "https://github.com/elihwyma/PugiSwift.git",
+  "https://github.com/eliseyOzerov/kiosk-swift.git",
   "https://github.com/ElizavetaIOS/Dialoggy.git",
   "https://github.com/ellneal/swift-promise.git",
   "https://github.com/ElveanApp/swift-edgar.git",


### PR DESCRIPTION
Adds Kiosk to the Swift Package Index package list.\n\nPackage URL: https://github.com/eliseyOzerov/kiosk-swift.git\n\nLocal validation:\n- swift package dump-package passed in the Kiosk package\n- swift test passed in the Kiosk package\n- swift validate.swift passed in PackageList\n\nCloses #14550