### PR TITLE
Add SwiftyUI

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4079,6 +4079,7 @@
   "https://github.com/handya/OhhAuth.git",
   "https://github.com/handya/TwitterVapor.git",
   "https://github.com/hanjoes/swift-termina.git",
+  "https://github.com/haoking/SwiftyUI.git",
   "https://github.com/happiness9721/line-bot-sdk-swift.git",
   "https://github.com/happn-app/officectl-model.git",
   "https://github.com/happn-app/RecursiveSyncDispatch.git",


### PR DESCRIPTION
Adds [SwiftyUI](https://github.com/haoking/SwiftyUI) — a lightweight, high-performance UIKit component library (self-drawing label via TextKit, GPU-composited image view, promise-based async chain, thread pool, toast, alert).

Checked against the requirements in the README:

- [x] Repository is publicly accessible
- [x] Valid `Package.swift` in the root folder
- [x] Written in Swift — `swift-tools-version: 6.0`, Swift 6 language mode
- [x] Semantic version tags — `2.0.0` (latest), plus `1.0.0`–`1.8.0`
- [x] `swift package dump-package` emits valid JSON (verified locally: `name: SwiftyUI`, `platforms: [ios 15.0]`, `products: [SwiftyUI]`)
- [x] URL includes the protocol and the `.git` extension
- [x] Compiles without errors — 113 unit tests and 6 UI tests pass on iOS 15+, CI green

Note on `validate.swift`: running it against a single URL reports `package moved` for this package, because it compares the input URL against the redirect target without normalizing, and GitHub's redirect drops the `.git` suffix. This is not specific to this package — packages already in the list behave identically (e.g. `handya/TwitterVapor.git`, `happiness9721/line-bot-sdk-swift.git`). The package-list code path normalizes via `normalized()`, which re-adds the extension, so this shouldn't affect the list validation.

The entry is inserted in case-insensitive sort order; the diff is a single added line.