### PR TITLE
Add Khac

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6929,6 +6929,7 @@
   "https://github.com/ngr-tc/swift-rtc.git",
   "https://github.com/ngtk/LoggerKit.git",
   "https://github.com/nh7a/geohash.git",
+  "https://github.com/nhannht/Khac.git",
   "https://github.com/nhoogendoorn/CardStack.git",
   "https://github.com/Nice-Healthcare/typeform-swift.git",
   "https://github.com/NicFontana/SwiftUI-CustomTabView.git",


### PR DESCRIPTION
Adds Khac, a natural-language date and time parser for Swift. It reads free text like "next Friday at 5pm" and returns dates, intervals, and components. Fourteen languages on one shared engine. MIT licensed, first release 0.1.0 is tagged.

Generated with [Claude Code](https://claude.com/claude-code)