### PR TITLE
Add organism

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6934,6 +6934,7 @@
   "https://github.com/ngtk/LoggerKit.git",
   "https://github.com/nh7a/geohash.git",
   "https://github.com/nhannht/Khac.git",
+  "https://github.com/nhannht/organism.git",
   "https://github.com/nhoogendoorn/CardStack.git",
   "https://github.com/Nice-Healthcare/typeform-swift.git",
   "https://github.com/NicFontana/SwiftUI-CustomTabView.git",


### PR DESCRIPTION
Adds organism, an Emacs org-mode parser for Swift. It is verified against org-element, org-mode's own reference parser: 120 of 120 conformance cases and 13 of 13 real-world files, plus a 1,312-case differential corpus. It ships a typed AST generated from its published JSON Schema, and has zero dependencies.

The repository also holds the language-agnostic conformance suite the parser is graded by, so a parser author in any language can point their own implementation at it.

MIT licensed. Latest release 0.2.0 is tagged, and `.spi.yml` opts into hosted DocC documentation.

Generated with [Claude Code](https://claude.com/claude-code)