### PR TITLE
Add ReadabilityScoreKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -10190,6 +10190,7 @@
   "https://github.com/theleftbit/BSWFoundation.git",
   "https://github.com/theleftbit/BSWInterfaceKit.git",
   "https://github.com/thelookoutway/ConfigCop.git",
+  "https://github.com/theluckystrike/ReadabilityScoreKit.git",
   "https://github.com/themomax/swift-docc-plugin.git",
   "https://github.com/theolampert/dkst.git",
   "https://github.com/theolampert/ECMASwift.git",


### PR DESCRIPTION
Adds `https://github.com/theluckystrike/ReadabilityScoreKit.git`.

Six classic English readability formulas (Flesch Reading Ease, Flesch-Kincaid Grade, Gunning Fog, SMOG, Coleman-Liau, ARI) in pure Swift with no dependencies and no data files.

- Public repository, MIT licensed
- Valid `Package.swift` in the root, swift-tools-version 5.9
- Tagged semantic version `1.0.0`
- `swift package dump-package` emits valid JSON
- `swift build` succeeds on the Swift 6.3 toolchain