### PR TITLE
Add izetg/SignalFusionKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4554,6 +4554,7 @@
   "https://github.com/ivnsch/SwiftCharts.git",
   "https://github.com/iwill/ExtSwift.git",
   "https://github.com/iwill/generic-json-swift.git",
+  "https://github.com/izetg/SignalFusionKit.git",
   "https://github.com/iZettle/Flow.git",
   "https://github.com/iZettle/Lift.git",
   "https://github.com/iZooto-App-Push/iZooto-XCFramework.git",


### PR DESCRIPTION
Adds https://github.com/izetg/SignalFusionKit — a small, unit-tested watchOS library for fusing HealthKit vitals and CoreMotion accelerometer signals into a risk classification. MIT licensed, tagged v1.0.0, Package.swift at root, targets watchOS 9 / iOS 16.