### PR TITLE
Add libtmux-swift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5633,6 +5633,7 @@
   "https://github.com/LiarPrincess/Violet.git",
   "https://github.com/libardoram/H3Swift.git",
   "https://github.com/libpag/pag-ios.git",
+  "https://github.com/libtmux/libtmux-swift.git",
   "https://github.com/Lickability/ObservableConverter.git",
   "https://github.com/lightbeamapps/TriggerKit.git",
   "https://github.com/Lighter-swift/Lighter.git",


### PR DESCRIPTION
[`libtmux-swift`](https://github.com/libtmux/libtmux-swift) — a Swift port of [libtmux](https://github.com/tmux-python/libtmux), for driving tmux from Swift. Three library products (`LibTmux`, `TmuxWorkspace`, `LibTmuxMCP`) and an MCP server executable.

Against the requirements:

- Public repository, `Package.swift` in the root, swift-tools-version 6.2.
- `swift package dump-package` outputs valid JSON.
- Tagged [`0.1.0-alpha.2`](https://github.com/libtmux/libtmux-swift/releases/tag/0.1.0-alpha.2), a semantic version.
- URL includes the protocol and the `.git` extension.
- Compiles, and its suite runs against tmux 3.2a through 3.7b on Linux and macOS on every push.

A `.spi.yml` is in the repository, naming the three library targets for documentation.