### PR TITLE
Add hegel-swift

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6843,6 +6843,7 @@
   "https://github.com/nashysolutions/files.git",
   "https://github.com/nashysolutions/foundation-dependencies.git",
   "https://github.com/nashysolutions/versioning.git",
+  "https://github.com/nassersala/hegel-swift.git",
   "https://github.com/natanrolnik/Lametric-Swift.git",
   "https://github.com/nate-parrott/openai-streaming-completions-swift.git",
   "https://github.com/nate-parrott/reeeed.git",


### PR DESCRIPTION
Adds https://github.com/nassersala/hegel-swift — property-based testing for Swift, powered by Hegel (Antithesis's PBT engine, built by the Hypothesis developers). Swift binding over libhegel with witness-style generators, engine-side shrinking, stateful testing, and Swift Testing integration. Tagged v0.1.0, MIT, macOS/iOS (Apple Silicon; the engine ships as a vendored XCFramework binary target, so Linux builds are expected to fail).