### PR TITLE
Add Choir

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4089,6 +4089,7 @@
   "https://github.com/hainayanda/Pharos.git",
   "https://github.com/hainayanda/Vellum.git",
   "https://github.com/HaishinKit/HaishinKit.swift.git",
+  "https://github.com/halalchristiano/Choir.git",
   "https://github.com/halcyonmobile/ReleaseRadar.git",
   "https://github.com/halcyonmobile/RestBird.git",
   "https://github.com/hallee/dotfiles.git",


### PR DESCRIPTION
Closes #14929

## New Packages

https://github.com/halalchristiano/Choir.git

## Why this is a manual pull request

I opened #14929 through the GitHub API, which does not apply the `Add Package` label. `.github/workflows/issues.yml` gates on that label, so the automation skipped the issue and never generated this PR. I can't add the label myself without write access here, so I've made the change by hand instead. Happy to close this and re-submit through the web form if you'd prefer — just say so.

The diff is exactly what `.github/add_package.swift` would have produced:

- The URL is already `https`-schemed with a `.git` suffix, so normalization is a no-op.
- It is not present in `denylist.json`.
- It was inserted with the same ordering the script uses (`absoluteString.lowercased()`, ascending), giving a single-line diff with no reordering of existing entries.
- The file was written with the same encoding settings, verified by confirming that a round-trip of the unmodified `packages.json` is byte-identical.

## Requirements checklist

- [x] Publicly accessible repository
- [x] Valid `Package.swift` in the root folder
- [x] Written in Swift 5.0 or later (tools version 6.3, Swift 6 language mode)
- [x] Contains a library product, `Choir`, usable from other Swift apps
- [x] Tagged as a semantic version (`v0.2.1`)
- [x] `swift package dump-package` outputs valid JSON
- [x] URL includes the protocol and the `.git` extension
- [x] Compiles without errors — CI builds and tests on macOS and cross-compiles for iOS, watchOS, tvOS and visionOS

The package also ships a `.spi.yml` declaring `Choir` as a documentation target, so DocC documentation can be built and hosted.
