### PR TITLE
Remove GITHUB_TOKEN from validate GH Action

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -22,10 +22,8 @@ jobs:
           GH_BODY: ${{ github.event.issue.body }}
 
       - name: Validate JSON
-        run: docker run --rm -e CI=true -e GITHUB_TOKEN=$GITHUB_TOKEN -v "$PWD:/host" -w /host $SWIFT_IMAGE swift validate.swift
+        run: docker run --rm -e CI=true -v "$PWD:/host" -w /host $SWIFT_IMAGE swift validate.swift
         id: validate
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check for Changes
         run: bash .github/check_for_changes.sh
@@ -91,10 +89,8 @@ jobs:
           GH_ISSUE: ${{ github.event.issue.number }}
 
       - name: Validate JSON
-        run: docker run --rm -e CI=true -e GITHUB_TOKEN=$GITHUB_TOKEN -v "$PWD:/host" -w /host $SWIFT_IMAGE swift validate.swift
+        run: docker run --rm -e CI=true -v "$PWD:/host" -w /host $SWIFT_IMAGE swift validate.swift
         id: validate
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check for Changes
         run: bash .github/check_for_changes.sh

--- a/validate.swift
+++ b/validate.swift
@@ -24,7 +24,6 @@ import FoundationNetworking
 
 enum Constants {
     static let githubPackageListURL = URL(string: "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/packages.json")!
-    static let githubToken = ProcessInfo.processInfo.environment["GITHUB_TOKEN"]
 }
 
 // MARK: - Type declarations
@@ -101,7 +100,7 @@ func shell(_ args: [String], at path: URL, returnStdOut: Bool = false, returnStd
     task.arguments = args
     task.currentDirectoryURL = path
     task.environment = ProcessInfo.processInfo.environment
-        .filter { !["GITHUB_TOKEN", "SPI_API_TOKEN"].contains($0.key) }
+        .filter { !["SPI_API_TOKEN"].contains($0.key) }
         .merging(["SPI_PROCESSING": "1"], uniquingKeysWith: { $1 })
     let stdout = Pipe()
     let stderr = Pipe()
@@ -245,10 +244,6 @@ extension URL {
 
 func fetch(_ url: URL, timeout: TimeInterval = 10) async throws -> Data {
     var request = URLRequest(url: url, timeoutInterval: timeout)
-
-    if let token = Constants.githubToken {
-        request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-    }
 
     let session = URLSession(configuration: .default)
     
@@ -522,10 +517,6 @@ func processPackageList() async throws {
 }
 
 func main(args: [String]) async throws {
-    if Constants.githubToken == nil {
-        print("Warning: Using anonymous authentication -- may run into rate limiting issues\n")
-    }
-
     switch try parseArgs(args) {
         case .processURL(let url):
             let resolvedURL = try await verifyURL(url)


### PR DESCRIPTION
A GITHUB_TOKEN was being injected into the container that runs the validate action. This token was auto generated by GitHub on every action run, and is used to try and avoid rate limits when hitting the GitHub API when querying information about the supplied package repo.

The volume of packages is so low we're unlikely to hit this limit, and doesn't justify the unnecessary risk of including a token.

If this causes rate limiting issues, revert this PR.