### PR TITLE
Add PonysAIBenchmark

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -11255,6 +11255,7 @@
   "https://github.com/wtpalexander/audi-connect.git",
   "https://github.com/wtpalexander/volvo-cars-api.git",
   "https://github.com/wtw-software/ios-UTMConversion.git",
+  "https://github.com/wujoe132/ponys-ai-resources-swift.git",
   "https://github.com/wulkano/Aperture.git",
   "https://github.com/wultra/passphrase-meter.git",
   "https://github.com/wuyu2015/BinaryStoreSwift.git",


### PR DESCRIPTION
Closes #14967

## New Package

https://github.com/wujoe132/ponys-ai-resources-swift.git

## Why this is a manual pull request

The issue was opened via the GitHub API, which cannot apply the repository-managed `Add Package` label. Since the issue workflow is gated on that label, this PR applies the same one-line, normalized and sorted `packages.json` change directly.

## Requirements checklist

- [x] Public repository with a valid root `Package.swift`
- [x] Swift tools version 5.9
- [x] Library product usable from other Swift applications
- [x] Semantic version tags `v1.0.0` and `v1.0.1`
- [x] `swift package dump-package` outputs valid JSON
- [x] Repository URL includes HTTPS and `.git`
- [x] `swift build` passes locally on 2026-08-22
- [x] MIT licensed; includes reproducible scoring, evidence requirements, and explicit failure cases