### PR TITLE
Set persist-credentials: false for actions/checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Validate JSON
         run: docker run --rm --env GITHUB_TOKEN=$GITHUB_TOKEN -v "$PWD:/host" -w /host $SWIFT_IMAGE swift validate.swift

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -14,7 +14,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Add Package to JSON
         run: docker run --rm -e CI=true -e GH_BODY="$GH_BODY" -v "$PWD:/host" -w /host $SWIFT_IMAGE swift .github/add_package.swift
@@ -82,7 +84,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Remove Package from JSON
         run: docker run --rm -e CI=true -e GH_BODY="$GH_BODY" -e GH_ISSUE="$GH_ISSUE" -v "$PWD:/host" -w /host $SWIFT_IMAGE swift .github/remove_package.swift


### PR DESCRIPTION
Don't copy the workflow's credential to the runners .git/config; it isn't required and it is unnecessary exposure.

A good short summary of the issue can be found here: https://yossarian.net/til/post/actions-checkout-can-leak-github-credentials/
