### PR TITLE
Stop interpolating step outputs in github-script bodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,13 @@ env:
   SWIFT_IMAGE: swiftlang/swift@sha256:805c5f57d2cb73adfee6821813afbc411d414e885122dd13a741c5192e74ce57  # swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-07-23-a swiftlang/swift:nightly-6.4.x-jammy
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions: {}
+
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -7,10 +7,16 @@ on:
 env:
   SWIFT_IMAGE: swiftlang/swift@sha256:805c5f57d2cb73adfee6821813afbc411d414e885122dd13a741c5192e74ce57  # swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-07-23-a swiftlang/swift:nightly-6.4.x-jammy
 
+permissions: {}
+
 jobs:
   add:
     runs-on: ubuntu-latest
     if: contains(github.event.issue.labels.*.name, 'Add Package')
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
 
     steps:
       - name: Checkout
@@ -55,32 +61,41 @@ jobs:
 
       - name: Update Issue (Success)
         if: steps.check.outputs.changes == 'true'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.issues.createComment({
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Thank you! We will approve and add these packages with #${{ steps.cpr.outputs.pull-request-number }}.'
+              body: `Thank you! We will approve and add these packages with #${process.env.PR_NUMBER}.`
             })
 
       - name: Update Issue (Failure)
         if: ${{ failure() || steps.check.outputs.changes != 'true' }}
-        uses: actions/github-script@v3
+        uses: actions/github-script@v9
+        env:
+          VALIDATE_ERROR: ${{ steps.validate.outputs.validateError }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.issues.createComment({
+            const validateError = process.env.VALIDATE_ERROR || 'None'
+            await github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: 'It looks like there’s nothing to do here!\n\nThe package may [already be in the package list](https://github.com/SwiftPackageIndex/PackageList/blob/main/packages.json) or on the [denylist](https://github.com/SwiftPackageIndex/PackageList/blob/main/denylist.json). Or, if you submitted the wrong URL or there’s a typo, please close this issue and [start a new one](https://github.com/SwiftPackageIndex/PackageList/issues/new/choose).\n\n>Validate Error: ${{ steps.validate.outputs.validateError || 'None' }}'
+                body: `It looks like there’s nothing to do here!\n\nThe package may [already be in the package list](https://github.com/SwiftPackageIndex/PackageList/blob/main/packages.json) or on the [denylist](https://github.com/SwiftPackageIndex/PackageList/blob/main/denylist.json). Or, if you submitted the wrong URL or there’s a typo, please close this issue and [start a new one](https://github.com/SwiftPackageIndex/PackageList/issues/new/choose).\n\n>Validate Error: ${validateError}`
             })
   remove:
     runs-on: ubuntu-latest
     if: contains(github.event.issue.labels.*.name, 'Remove Package')
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
 
     steps:
       - name: Checkout
@@ -127,26 +142,31 @@ jobs:
 
       - name: Update Issue (Success)
         if: steps.check.outputs.changes == 'true'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.issues.createComment({
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Thank you! We will approve and remove these packages with #${{ steps.cpr.outputs.pull-request-number }}.'
+              body: `Thank you! We will approve and remove these packages with #${process.env.PR_NUMBER}.`
             })
 
       - name: Update Issue (Failure)
         if: ${{ failure() || steps.check.outputs.changes != 'true' }}
-        uses: actions/github-script@v3
+        uses: actions/github-script@v9
+        env:
+          VALIDATE_ERROR: ${{ steps.validate.outputs.validateError }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.issues.createComment({
+            const validateError = process.env.VALIDATE_ERROR || 'None'
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Oh no! We were unable to detect any valid packages in your submission. If you submitted the wrong URL and would like to update it, please [open a new issue](https://github.com/SwiftPackageIndex/PackageList/issues/new/choose).\n\n>Validate Error: ${{ steps.validate.outputs.validateError || 'None' }}'
+              body: `Oh no! We were unable to detect any valid packages in your submission. If you submitted the wrong URL and would like to update it, please [open a new issue](https://github.com/SwiftPackageIndex/PackageList/issues/new/choose).\n\n>Validate Error: ${validateError}`
             })

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,8 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SPI_API_TOKEN: ${{ secrets.SPI_API_TOKEN }}
 
+permissions: {}
+
 jobs:
 
   build_validator:
@@ -35,6 +37,8 @@ jobs:
     env:
       CONCURRENCY: "10"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     container:
       image: swift:6.3-jammy
     steps:
@@ -68,6 +72,9 @@ jobs:
   check_dependencies:
     needs: check_redirects
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     container:
       image: swift:6.3-jammy
     steps:


### PR DESCRIPTION
The `${{ }}` substitution happens before Node parses the script in the actions, so a validation error could be interpreted as source code instead of as a string.

Transport the values through `env:` and read them back inside a template literal, which is read from inside the Node script safely.

Bump github-script from v3 to v9, which required some small tweaks to the script bodies.

Finally, add explicit permissions blocks to all three workflows. This enforces least priviledge on each step.
