### PR TITLE
Evaluate manifests in a container with no network

### DIFF
--- a/.github/evaluate_manifests.sh
+++ b/.github/evaluate_manifests.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Evaluates every manifest set that validate.swift fetched, each in its own restricted
+# container. validate.swift writes one directory per package into SPI_MANIFEST_DIR.
+# `manifests/` for the Package*.swift files, `url` for the package they came from.
+#
+# The container is where third party manifest code runs, so it has no network, no token, an
+# unprivileged uid, nothing writable and a wall clock. All that comes back out of it is an
+# exit status per package.
+
+set -uo pipefail
+
+manifest_root="${1:?usage: evaluate_manifests.sh <directory written by validate.swift>}"
+timeout_seconds="${SPI_MANIFEST_TIMEOUT:-120}"
+: "${SWIFT_IMAGE:?SWIFT_IMAGE must be set to the image CI evaluates manifests with}"
+
+# A manifest can simply refuse to finish, and SwiftPM runs it in a process group of its own,
+# so signalling the process group we started does not reach it. The termination of the container's
+# PID 1 takes the whole PID namespace with it.
+evaluate() {
+    docker run --rm \
+        --label spi-manifest-evaluation \
+        --network none \
+        --user 65534:65534 \
+        --cap-drop ALL \
+        --security-opt no-new-privileges \
+        --pids-limit 256 \
+        --memory 2g \
+        --cpus 2 \
+        --ulimit nofile=1024 \
+        --ulimit fsize=104857600 \
+        --tmpfs /tmp:rw,exec,mode=1777,size=1g \
+        --env HOME=/tmp \
+        --env SPI_PROCESSING=1 \
+        --volume "$1:/pkg:ro" \
+        --workdir /pkg \
+        "$SWIFT_IMAGE" \
+        timeout --signal=KILL "$timeout_seconds" \
+        swift package --scratch-path /tmp/scratch dump-package > /dev/null
+}
+
+sanitized() {
+    tr -d '\r\n' | tr -cd '[:alnum:] .,:/_@-' | cut -c1-200
+}
+
+report_failure() {
+    [ -n "${GITHUB_OUTPUT:-}" ] || return 0
+    echo "validateError=$1" >> "$GITHUB_OUTPUT"
+}
+
+# A handover directory that is missing entirely means the two steps disagree about where it
+# is, which would otherwise look exactly like a run with nothing to evaluate.
+[ -d "$manifest_root" ] || { echo "no handover directory at $manifest_root"; exit 1; }
+
+shopt -s nullglob
+evaluated=()
+failed=()
+
+for directory in "$manifest_root"/*/; do
+    [ -d "$directory/manifests" ] || continue
+    package="$(sanitized < "$directory/url" 2>/dev/null)"
+    package="${package:-$directory}"
+    echo "evaluating manifests for $package"
+    evaluated+=("$package")
+    if ! evaluate "$directory/manifests"; then
+        failed+=("$package")
+    fi
+done
+
+if [ "${#failed[@]}" != 0 ]; then
+    printf 'manifest evaluation failed: %s\n' "${failed[@]}"
+    report_failure "manifest evaluation failed: ${failed[0]}"
+    exit 1
+fi
+
+echo "evaluated ${#evaluated[@]} package(s), every manifest loaded"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ permissions: {}
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -26,4 +27,14 @@ jobs:
           persist-credentials: false
 
       - name: Validate JSON
-        run: docker run --rm --env GITHUB_TOKEN=$GITHUB_TOKEN -v "$PWD:/host" -w /host $SWIFT_IMAGE swift validate.swift
+        run: |
+          mkdir -p "$RUNNER_TEMP/manifests"
+          docker run --rm \
+            --env GITHUB_TOKEN="$GITHUB_TOKEN" \
+            --env SPI_MANIFEST_DIR=/manifests \
+            -v "$RUNNER_TEMP/manifests:/manifests" \
+            -v "$PWD:/host" -w /host \
+            "$SWIFT_IMAGE" swift validate.swift
+
+      - name: Evaluate manifests
+        run: bash .github/evaluate_manifests.sh "$RUNNER_TEMP/manifests"

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -12,6 +12,7 @@ permissions: {}
 jobs:
   add:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: contains(github.event.issue.labels.*.name, 'Add Package')
     permissions:
       contents: write
@@ -29,11 +30,26 @@ jobs:
         env:
           GH_BODY: ${{ github.event.issue.body }}
 
+      # Fetches packages and hands them over to the next
+      # step where they are evaluated by .github/evaluate_manifests.sh.
       - name: Validate JSON
-        run: docker run --rm -e CI=true -e GITHUB_TOKEN=$GITHUB_TOKEN -v "$PWD:/host" -w /host $SWIFT_IMAGE swift validate.swift
+        run: |
+          mkdir -p "$RUNNER_TEMP/manifests"
+          docker run --rm \
+            -e CI=true \
+            -e GITHUB_TOKEN="$GITHUB_TOKEN" \
+            -e SPI_MANIFEST_DIR=/manifests \
+            -v "$RUNNER_TEMP/manifests:/manifests" \
+            -v "$PWD:/host" -w /host \
+            "$SWIFT_IMAGE" swift validate.swift
         id: validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Runs third party code, holds nothing and can reach nothing.
+      - name: Evaluate manifests
+        run: bash .github/evaluate_manifests.sh "$RUNNER_TEMP/manifests"
+        id: evaluate
 
       - name: Check for Changes
         run: bash .github/check_for_changes.sh
@@ -78,7 +94,7 @@ jobs:
         if: ${{ failure() || steps.check.outputs.changes != 'true' }}
         uses: actions/github-script@v9
         env:
-          VALIDATE_ERROR: ${{ steps.validate.outputs.validateError }}
+          VALIDATE_ERROR: ${{ steps.validate.outputs.validateError || steps.evaluate.outputs.validateError }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -91,6 +107,7 @@ jobs:
             })
   remove:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: contains(github.event.issue.labels.*.name, 'Remove Package')
     permissions:
       contents: write
@@ -109,11 +126,26 @@ jobs:
           GH_BODY: ${{ github.event.issue.body }}
           GH_ISSUE: ${{ github.event.issue.number }}
 
+      # Fetches packages and hands them over to the next
+      # step where they are evaluated by .github/evaluate_manifests.sh.
       - name: Validate JSON
-        run: docker run --rm -e CI=true -e GITHUB_TOKEN=$GITHUB_TOKEN -v "$PWD:/host" -w /host $SWIFT_IMAGE swift validate.swift
+        run: |
+          mkdir -p "$RUNNER_TEMP/manifests"
+          docker run --rm \
+            -e CI=true \
+            -e GITHUB_TOKEN="$GITHUB_TOKEN" \
+            -e SPI_MANIFEST_DIR=/manifests \
+            -v "$RUNNER_TEMP/manifests:/manifests" \
+            -v "$PWD:/host" -w /host \
+            "$SWIFT_IMAGE" swift validate.swift
         id: validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Runs third party code, holds nothing and can reach nothing.
+      - name: Evaluate manifests
+        run: bash .github/evaluate_manifests.sh "$RUNNER_TEMP/manifests"
+        id: evaluate
 
       - name: Check for Changes
         run: bash .github/check_for_changes.sh
@@ -159,7 +191,7 @@ jobs:
         if: ${{ failure() || steps.check.outputs.changes != 'true' }}
         uses: actions/github-script@v9
         env:
-          VALIDATE_ERROR: ${{ steps.validate.outputs.validateError }}
+          VALIDATE_ERROR: ${{ steps.validate.outputs.validateError || steps.evaluate.outputs.validateError }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/packages.json
+++ b/packages.json
@@ -2491,6 +2491,7 @@
   "https://github.com/davedelong/time.git",
   "https://github.com/davedufresne/SwiftParsec.git",
   "https://github.com/daveverwer/CriticMarkup.git",
+  "https://github.com/daveverwer/LeftPad.git",
   "https://github.com/DaveWoodCom/XCGLogger.git",
   "https://github.com/david-livadaru/DLAngle.git",
   "https://github.com/david-livadaru/DLCoreGraphics.git",

--- a/validate.swift
+++ b/validate.swift
@@ -25,29 +25,30 @@ import FoundationNetworking
 enum Constants {
     static let githubPackageListURL = URL(string: "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/packages.json")!
     static let githubToken = ProcessInfo.processInfo.environment["GITHUB_TOKEN"]
+    static let manifestDirectory = ProcessInfo.processInfo.environment["SPI_MANIFEST_DIR"]
+        .map { URL(fileURLWithPath: $0) }
 }
 
 // MARK: - Type declarations
 
 enum AppError: Error {
     case invalidURL(URL)
+    case manifestDirectoryNotSet
     case manifestNotFound(URL)
     case networkingError(Error)
     case notFound(URL)
     case outputIdentical
-    case packageDumpError(String)
-    case packageDumpTimeout
     case packageListChanged
     case packageMoved
     case rateLimitExceeded(URL, reportedLimit: Int)
-    case shellCommandFailed(command: String, terminationStatus: Int, errorMessage: String)
-    case shellCommandTimeout(command: String)
     case syntaxError(String)
 
     var localizedDescription: String {
         switch self {
             case .invalidURL(let url):
                 return "invalid url: \(url)"
+            case .manifestDirectoryNotSet:
+                return "SPI_MANIFEST_DIR is not set. Manifests are fetched there for .github/evaluate_manifests.sh to evaluate, so set it to a directory that already exists."
             case .manifestNotFound(let url):
                 return "no package manifest found at url: \(url)"
             case .networkingError(let error):
@@ -56,20 +57,12 @@ enum AppError: Error {
                 return "url not found (404): \(url)"
             case .outputIdentical:
                 return "resulting package.json is unchanged. This typically means the package is already in the index."
-            case .packageDumpError(let msg):
-                return "package dump failed: \(msg)"
-            case .packageDumpTimeout:
-                return "timeout while running `swift package dump-package`"
             case .packageListChanged:
                 return "package list was modified"
             case .packageMoved:
                 return "package moved"
             case let .rateLimitExceeded(url, limit):
                 return "rate limit of \(limit) exceeded while requesting url: \(url)"
-            case let .shellCommandFailed(command: cmd, terminationStatus: status, errorMessage: message):
-                return "command failed: \(cmd), status: \(status), error: \(message)"
-            case let .shellCommandTimeout(command: cmd):
-                return "command `\(cmd)` timed out"
             case .syntaxError(let msg):
                 return msg
         }
@@ -79,83 +72,6 @@ enum AppError: Error {
 enum RunMode {
     case processURL(URL)
     case processPackageList
-}
-
-struct Package: Decodable {
-    let name: String
-}
-
-// MARK: - Shell helpers
-
-// Via Tim Condon
-
-@discardableResult
-func shell(_ args: String..., at path: URL, returnStdOut: Bool = false, returnStdErr: Bool = false, stdIn: Pipe? = nil, environment: [String: String]) throws -> (status: Int32, stdout: String?, stderr: String?) {
-    return try shell(args, at: path, returnStdOut: returnStdOut, returnStdErr: returnStdErr, stdIn: stdIn, environment: environment)
-}
-
-@discardableResult
-func shell(_ args: [String], at path: URL, returnStdOut: Bool = false, returnStdErr: Bool = false, stdIn: Pipe? = nil, environment: [String: String]) throws -> (status: Int32, stdout: String?, stderr: String?) {
-    let task = Process()
-    task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    task.arguments = args
-    task.currentDirectoryURL = path
-    task.environment = environment
-    let stdout = Pipe()
-    let stderr = Pipe()
-    if returnStdOut {
-        task.standardOutput = stdout
-    }
-    if returnStdErr {
-        task.standardError = stderr
-    }
-    if let stdIn = stdIn {
-        task.standardInput = stdIn
-    }
-    
-    // Workaround https://github.com/swiftlang/swift-corelibs-foundation/issues/5197
-    let group = DispatchGroup()
-    
-    try task.run()
-
-    let outputData = QueueIsolated<Data?>(nil)
-    let errorData = QueueIsolated<Data?>(nil)
-
-    group.enter()
-    Thread { // read full output in a separate thread
-        let data = try? stdout.fileHandleForReading.readToEnd()
-        outputData.withValue { $0 = data } 
-        group.leave()
-    }.start()
-    
-    group.enter()
-    Thread {  // read full error output in a separate thread
-        let data = try? stderr.fileHandleForReading.readToEnd()
-        errorData.withValue { $0 = data }
-        group.leave()
-    }.start()
-    
-    task.waitUntilExit()
-    
-    // wait until the reader threads complete
-    if .timedOut == group.wait(timeout: .now() + .seconds(30)) {
-        throw AppError.shellCommandTimeout(command: args.joined(separator: " "))
-    }
-    
-    guard task.terminationStatus == 0 else {
-        let message = errorData.withValue { $0.map(\.string)?.trimmingCharacters(in: .whitespacesAndNewlines) } ?? ""
-        throw AppError.shellCommandFailed(command: args.joined(separator: " "), terminationStatus: Int(task.terminationStatus), errorMessage: message)
-    }
-    
-    return (status: task.terminationStatus,
-            stdout: outputData.withValue { $0 }.map(\.string),
-            stderr: errorData.withValue { $0 }.map(\.string))
-}
-
-extension Data {
-    var string: String {
-        String(decoding: self, as: UTF8.self)
-    }
 }
 
 // Other helpers
@@ -400,51 +316,34 @@ func getManifestURLs(_ url: URL) async throws -> [URL] {
     }
 }
 
-func createTempDir() throws -> URL {
+// MARK: - Manifests
+
+// Once we've pulled the manifests we can hand them over to the evaluation step which can safely run 3rd party code. 
+func handOverManifests(of url: URL, to root: URL) async throws {
     let fm = FileManager.default
-    let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-    try fm.createDirectory(at: tempDir, withIntermediateDirectories: false, attributes: nil)
-    return tempDir
-}
+    let directory = root.appendingPathComponent(UUID().uuidString)
+    let manifests = directory.appendingPathComponent("manifests")
 
-func manifestEvaluationEnvironment() -> [String: String] {
-    let path = ProcessInfo.processInfo.environment["PATH"] ?? "/usr/local/bin:/usr/bin:/bin"
-    return ["SPI_PROCESSING": "1", "PATH": path]
-}
+    // Not creating intermediates, so a handover directory that was never mounted fails here
+    // rather than leaving the evaluation step with nothing to find and nothing to report.
+    try fm.createDirectory(at: directory, withIntermediateDirectories: false)
+    try fm.createDirectory(at: manifests, withIntermediateDirectories: false)
 
-func runDumpPackage(at path: URL, timeout: TimeInterval = 20) throws -> Data {
-    let (status, stdout, stderr) = try shell("swift", "package", "dump-package",
-                                             at: path, returnStdOut: true, returnStdErr: true, environment: manifestEvaluationEnvironment())
-
-    switch status {
-        case 0:
-            return stdout.map { Data($0.utf8) } ?? Data()
-        case 15:
-            throw AppError.packageDumpTimeout
-        default:
-            let error = stderr ?? "(nil)"
-            throw AppError.packageDumpError(error)
-    }
-}
-
-@discardableResult
-func dumpPackage(url: URL) async throws -> Package {
-    let tempDir = try createTempDir()
-    
     for manifestURL in try await getManifestURLs(url) {
         let manifest = try await fetch(manifestURL)
-        let fileURL = tempDir.appendingPathComponent(manifestURL.lastPathComponent)
-        try manifest.write(to: fileURL)
+        try manifest.write(to: manifests.appendingPathComponent(manifestURL.lastPathComponent))
     }
 
-    let json = try runDumpPackage(at: tempDir)
-    return try JSONDecoder().decode(Package.self, from: json)
+    // The url alongside the manifests rather than among them, so the evaluation step can name
+    // the package it could not evaluate while mounting nothing but manifests.
+    try Data(url.absoluteString.utf8).write(to: directory.appendingPathComponent("url"))
 }
 
 func verifyURL(_ url: URL) async throws -> URL {
     print("verifying", url)
     guard let resolvedURL = url.followingRedirects() else { throw AppError.invalidURL(url) }
-    try await dumpPackage(url: resolvedURL)
+    guard let handoverDirectory = Constants.manifestDirectory else { throw AppError.manifestDirectoryNotSet }
+    try await handOverManifests(of: resolvedURL, to: handoverDirectory)
     return resolvedURL
 }
 


### PR DESCRIPTION
`swift dump-package` runs third party code which may access the file system, environment variables, and the network. This command was running in the same container that holds GITHUB_TOKEN and had a network, so a hostile manifest could read the token out of /proc and could exfiltrate it.

validate.swift now just fetches manifests into `SPI_MANIFEST_DIR`, one directory per package, and `evaluate_manifests.sh` runs each set in its own container with no network, an unprivileged uid, a read-only mount and a hard timeout. All that comes back out is an exit status per package. They are split up in the workflow because validate.swift needs the network for the GitHub API and there's no docker in the swift image, so it can't wrap itself.

Since it no longer runs anything, shell(), the timeout handling and a few error cases can be removed from validate.swift (whichends up about 100 lines shorter). Running it locally you'll need to set `SPI_MANIFEST_DIR` now, and it won't tell you whether a manifest compiles; evaluate_manifests.sh does that.
