### PR TITLE
Only run CI on pull requests labelled force-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [ opened, synchronize, reopened, labeled ]
   pull_request_review:
     types: [submitted]
 
@@ -16,6 +17,7 @@ permissions: {}
 
 jobs:
   validate:
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'force-ci')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Temporarily allow the validate job to run only when we give a PR the force-ci label.