### PR TITLE
Evaluate nightly's manifests in a container with no network

### DIFF
--- a/.github/evaluate_manifests.sh
+++ b/.github/evaluate_manifests.sh
@@ -1,18 +1,33 @@
 #!/usr/bin/env bash
 
-# Evaluates every manifest set that validate.swift fetched, each in its own restricted
-# container. validate.swift writes one directory per package into SPI_MANIFEST_DIR.
-# `manifests/` for the Package*.swift files, `url` for the package they came from.
+# Evaluates every manifest set that was fetched for it, each in its own restricted container.
+# The fetching step - validate.swift for a submission, `validator check-dependencies` for the
+# nightly audit - writes one directory per package into the handover directory. `manifests/` for
+# the Package*.swift files, `url` for the package they came from.
 #
 # The container is where third party manifest code runs, so it has no network, no token, an
 # unprivileged uid, nothing writable and a wall clock. All that comes back out of it is an
 # exit status per package.
+#
+# SPI_EVALUATION_MODE picks what a manifest that does not load means:
+#
+#   fail   (default) the run fails. A submitted package that does not build is the submitter's
+#          problem and they need to hear about it.
+#   report the package is marked `failed` and the run continues. A candidate dependency that does
+#          not build is simply not added, and one bad package on the index must not stop the
+#          nightly audit.
 
 set -uo pipefail
 
-manifest_root="${1:?usage: evaluate_manifests.sh <directory written by validate.swift>}"
+manifest_root="${1:?usage: evaluate_manifests.sh <directory the manifests were fetched into>}"
 timeout_seconds="${SPI_MANIFEST_TIMEOUT:-120}"
+mode="${SPI_EVALUATION_MODE:-fail}"
 : "${SWIFT_IMAGE:?SWIFT_IMAGE must be set to the image CI evaluates manifests with}"
+
+case "$mode" in
+    fail|report) ;;
+    *) echo "SPI_EVALUATION_MODE must be 'fail' or 'report', not '$mode'"; exit 1 ;;
+esac
 
 # A manifest can simply refuse to finish, and SwiftPM runs it in a process group of its own,
 # so signalling the process group we started does not reach it. The termination of the container's
@@ -64,8 +79,19 @@ for directory in "$manifest_root"/*/; do
     evaluated+=("$package")
     if ! evaluate "$directory/manifests"; then
         failed+=("$package")
+        # The marker goes beside `manifests`, never inside it, so nothing the container could
+        # reach can forge it.
+        [ "$mode" = report ] && touch "$directory/failed"
     fi
 done
+
+if [ "$mode" = report ]; then
+    # Signing off so the next step can tell "nothing failed" apart from "this never ran".
+    touch "$manifest_root/evaluated"
+    [ "${#failed[@]}" != 0 ] && printf 'could not evaluate: %s\n' "${failed[@]}"
+    echo "evaluated ${#evaluated[@]} package(s), ${#failed[@]} did not load"
+    exit 0
+fi
 
 if [ "${#failed[@]}" != 0 ]; then
     printf 'manifest evaluation failed: %s\n' "${failed[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,8 @@ jobs:
             -v "$PWD:/host" -w /host \
             "$SWIFT_IMAGE" swift validate.swift
 
+      # Runs third party code, holds nothing and can reach nothing.
       - name: Evaluate manifests
+        env:
+          SPI_EVALUATION_MODE: fail
         run: bash .github/evaluate_manifests.sh "$RUNNER_TEMP/manifests"

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -48,6 +48,8 @@ jobs:
 
       # Runs third party code, holds nothing and can reach nothing.
       - name: Evaluate manifests
+        env:
+          SPI_EVALUATION_MODE: fail
         run: bash .github/evaluate_manifests.sh "$RUNNER_TEMP/manifests"
         id: evaluate
 
@@ -144,6 +146,8 @@ jobs:
 
       # Runs third party code, holds nothing and can reach nothing.
       - name: Evaluate manifests
+        env:
+          SPI_EVALUATION_MODE: fail
         run: bash .github/evaluate_manifests.sh "$RUNNER_TEMP/manifests"
         id: evaluate
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,8 +9,6 @@ env:
   # Keep in step with the `container:` images below. Those cannot reference `env`, so the value is
   # repeated rather than shared. This one is what the manifest evaluation containers run.
   SWIFT_IMAGE: swift:6.3-jammy
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SPI_API_TOKEN: ${{ secrets.SPI_API_TOKEN }}
 
 permissions: {}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 6 * * *'
 
 env:
+  # Keep in step with the `container:` images below. Those cannot reference `env`, so the value is
+  # repeated rather than shared. This one is what the manifest evaluation containers run.
+  SWIFT_IMAGE: swift:6.3-jammy
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SPI_API_TOKEN: ${{ secrets.SPI_API_TOKEN }}
 
@@ -76,11 +79,12 @@ jobs:
   check_dependencies:
     needs: check_redirects
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       contents: write
       pull-requests: write
-    container:
-      image: swift:6.3-jammy
+    # No `container:` here, unlike the jobs above: evaluating manifests means running third party
+    # code in a container of its own, and the runner's docker is not reachable from inside one.
     steps:
       # we need to check out the repo in the last step in order to create a PR
       - name: Checkout
@@ -98,24 +102,54 @@ jobs:
         with:
           name: redirect-checked.json
 
-      - name: Check dependencies
-        uses: nick-fields/retry@v2
+      # Fetches candidate manifests and hands them over to the next step, which is where they are
+      # evaluated. This holds the tokens but runs nothing it downloads.
+      - name: Fetch dependency manifests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPI_API_TOKEN: ${{ secrets.SPI_API_TOKEN }}
-        with:
-          timeout_minutes: 60
-          max_attempts: 1
-          retry_on: error
-          command: |
-            chmod +x ./validator
+        run: |
+          chmod +x ./validator
+          mkdir -p "$RUNNER_TEMP/manifests"
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            --env GITHUB_TOKEN="$GITHUB_TOKEN" \
+            -v "$RUNNER_TEMP/manifests:/manifests" \
+            -v "$PWD:/host" -w /host \
+            "$SWIFT_IMAGE" \
             ./validator check-dependencies \
-                --spi-api-token $SPI_API_TOKEN \
-                --input redirect-checked.json --output packages.json \
-                --limit 20
+              --spi-api-token "$SPI_API_TOKEN" \
+              --input redirect-checked.json \
+              --manifest-dir /manifests \
+              --limit 20
+
+      # Runs third party code, holds nothing and can reach nothing. `report` because a candidate
+      # dependency that does not build is simply not added, rather than a failed audit.
+      - name: Evaluate manifests
+        env:
+          SPI_EVALUATION_MODE: report
+        run: bash .github/evaluate_manifests.sh "$RUNNER_TEMP/manifests"
+
+      # Both write into the checkout that the pull request is raised from, so they run as the
+      # runner's own uid rather than leaving root owned files behind.
+      - name: Add validated dependencies
+        run: |
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -v "$RUNNER_TEMP/manifests:/manifests" \
+            -v "$PWD:/host" -w /host \
+            "$SWIFT_IMAGE" \
+            ./validator add-validated-dependencies \
+              --manifest-dir /manifests \
+              --input redirect-checked.json --output packages.json
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -v "$PWD:/host" -w /host \
+            "$SWIFT_IMAGE" \
             ./validator apply-deny-list -p packages.json -d denylist.json
-            # Stop artifacts from appearing in the PR
-            rm -f redirect-checked.json validator
+          # Stop artifacts from appearing in the PR
+          rm -f redirect-checked.json validator
+
       - name: Create pull request
         id: cpr
         uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
Follow on to c40d1a7639aa7d3fc5d67c6e72180ae3d9a828e7, taking similar steps to isolate `swift dump-package` invocations by running them in a container with no networking, non root user, without secrets, and then storing the output of the command on a shared directory that the subsequent steps can access.

Added `SPI_EVALUATION_MODE` to evaluate_manifests.sh to control whether we fail when encountering a manifest that doesn't parse, or if we just report it (nightly uses `report`, PR validation uses `fail`).

This depends on https://github.com/SwiftPackageIndex/PackageList-Validator/pull/79