### PR TITLE
Tell SwiftPM where to put its caches

### DIFF
--- a/.github/evaluate_manifests.sh
+++ b/.github/evaluate_manifests.sh
@@ -51,7 +51,12 @@ evaluate() {
         --workdir /pkg \
         "$SWIFT_IMAGE" \
         timeout --signal=KILL "$timeout_seconds" \
-        swift package --scratch-path /tmp/scratch dump-package > /dev/null
+        swift package \
+            --scratch-path /tmp/scratch \
+            --cache-path /tmp/cache \
+            --config-path /tmp/config \
+            --security-path /tmp/security \
+            dump-package > /dev/null
 }
 
 sanitized() {


### PR DESCRIPTION
Every package logged two warnings about /nonexistent/.swiftpm not being writable, which polluted the logs with noise.
