### PR TITLE
Supply deny-list to check-dependencies and bump limit

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -118,8 +118,9 @@ jobs:
             ./validator check-dependencies \
               --spi-api-token "$SPI_API_TOKEN" \
               --input redirect-checked.json \
+              --deny-list denylist.json \
               --manifest-dir /manifests \
-              --limit 20
+              --limit 40
 
       # Runs third party code, holds nothing and can reach nothing. `report` because a candidate
       # dependency that does not build is simply not added, rather than a failed audit.


### PR DESCRIPTION
With the recent change to the nightly job, the dependency check altered the --limit argument so that it counts against packages fetched instead of packages that need updating.

Skip dpendencies in the denylist, which avoids these packages counting towards the limit. Also, bump the limit, since there are ~10 packages that fail to parse and count towards the limit. Between failing packages and denylisted packages a nightly wasn't processing enough packages.