### PR TITLE
Add RealDentalCostsAPI (shoopeur-eng/realdentalcosts-swift)

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -9062,6 +9062,7 @@
   "https://github.com/ShivaHuang/swift-nanoid.git",
   "https://github.com/shogo4405/Logboard.git",
   "https://github.com/shogo4405/usage.git",
+  "https://github.com/shoopeur-eng/realdentalcosts-swift.git",
   "https://github.com/Shopify/FunctionalTableData.git",
   "https://github.com/shotastage/Fileable.swift.git",
   "https://github.com/shrudge/avie.git",


### PR DESCRIPTION
Adds RealDentalCostsAPI, a small Swift client (iOS 13+/macOS 10.15+, swift-tools 5.5, MIT) for the Real Dental Costs open API: U.S. dental procedure prices by state and Medicaid paid-per-claim-line by CDT code. The repo has Package.swift, LICENSE and .spi.yml.