### PR TITLE
Add helgafinn/xcprune

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4175,6 +4175,7 @@
   "https://github.com/helbertgs/OpenGLFW.git",
   "https://github.com/helbertgs/OpenSpatial.git",
   "https://github.com/helenhell/ETCarouSwift.git",
+  "https://github.com/helgafinn/xcprune.git",
   "https://github.com/helikon-labs/subvt-data-swift.git",
   "https://github.com/helje5/Highlightr.git",
   "https://github.com/helje5/MicroExpress.git",


### PR DESCRIPTION
Adds [xcprune](https://github.com/helgafinn/xcprune), a CLI that finds unused images, colors, and localization keys in an Xcode project.

It resolves a resource as used through a string literal, the Swift symbol Xcode generates for an asset, a storyboard or xib attribute, an `Info.plist` entry, or implicit SwiftUI localization. It reports only and never deletes; where a runtime-decided lookup such as `UIImage(named: variable)` exists it marks results for that kind low confidence rather than risking a false positive.

Requirements checked before submitting:

- [x] Public repository
- [x] Valid `Package.swift` in the root folder
- [x] Swift 5.9 tools version
- [x] Tagged semantic version release (`v1.0.0`)
- [x] `swift package dump-package` emits valid JSON
- [x] Package URL includes the protocol and the `.git` extension
- [x] Compiles without errors (`swift build -c release`)
- [x] Entry keeps the list case-insensitively sorted, and the file's existing formatting is unchanged

No external dependencies.