### PR TITLE
Add 98ChimpInc/touch-indicator-ios-sdk

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -161,6 +161,7 @@
   "https://github.com/623637646/SwiftHook.git",
   "https://github.com/6639835/Toast.git",
   "https://github.com/8rightside/Resistance.git",
+  "https://github.com/98ChimpInc/touch-indicator-ios-sdk.git",
   "https://github.com/9alvaro0/Pry.git",
   "https://github.com/9uiLe/swift-app-macros.git",
   "https://github.com/9uiLe/swift-scoped-animation.git",


### PR DESCRIPTION
Zero-dependency Swift package (iOS 15+) that draws a circle under every finger for demo videos and screen recordings. Tagged v1.0.1, MIT.