### PR TITLE
Add ShotKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1398,6 +1398,7 @@
   "https://github.com/binaryscraping/swift-log.git",
   "https://github.com/binaryscraping/swift-sqlite.git",
   "https://github.com/binayshaw7777/Leaflekt-Maps.git",
+  "https://github.com/birangdev/ShotKit.git",
   "https://github.com/bircni/BetterTabBar.git",
   "https://github.com/birkoof/LocationRadiusPicker.git",
   "https://github.com/bitflying/SwiftKeccak.git",


### PR DESCRIPTION
Closes #15103

Adds [ShotKit](https://github.com/birangdev/ShotKit) — a small, project-agnostic App Store screenshot engine for SwiftUI apps on macOS and iOS.

- Public repo, MIT licensed
- Valid `Package.swift` at root (swift-tools-version 5.9), one `.library` product (`ShotKit`)
- Tagged release `1.0.0`
- CI green (`swift build` + `swift test`)
- `.spi.yml` present for docs