### PR TITLE
Add CJStanfield/CoreAudioTapKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1917,6 +1917,7 @@
   "https://github.com/cirruslabs/opentelemetry-swift.git",
   "https://github.com/CiscoDevNet/AppDynamicsAgent.git",
   "https://github.com/ciscoriordan/svg-flags.git",
+  "https://github.com/CJStanfield/CoreAudioTapKit.git",
   "https://github.com/ckanchan/CDKOraccInterface.git",
   "https://github.com/ckanchan/CDKSwiftOracc.git",
   "https://github.com/Clafou/DevicePpi.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [CoreAudioTapKit](https://github.com/CJStanfield/CoreAudioTapKit/)

Capture, process and play back macOS system audio on one clock: a device-scoped Core Audio process tap and the physical output in a single aggregate device, driven by one IOProc. MIT. macOS 14.2+.

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.