### PR TITLE
Add Inttegro SDK for iOS

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -11595,6 +11595,7 @@
   "https://github.com/zcash/zcash-swift-wallet-sdk.git",
   "https://github.com/Ze0nC/SwiftPygments.git",
   "https://github.com/Ze0nC/SwiftPygmentsPublishPlugin.git",
+  "https://github.com/zebodotdev/inttegro-sdk-ios.git",
   "https://github.com/zecdev/zcash-swift-payment-uri.git",
   "https://github.com/Zedd0202/ZeddKit.git",
   "https://github.com/ZeeQL/CLibPQ.git",


### PR DESCRIPTION
The package being submitted is:

* [Inttegro SDK for iOS](https://github.com/zebodotdev/inttegro-sdk-ios)

## Checklist

- [x] The package repository is publicly accessible.
- [x] The package contains `Package.swift` in the root folder.
- [x] The package uses Swift 6.0.
- [x] The package exposes the `Inttegro` library product.
- [x] The package has a signed semantic-version release, `v0.1.0`.
- [x] `swift package dump-package` outputs valid JSON with the latest local Swift toolchain.
- [x] The package URL includes the protocol and `.git` extension.
- [x] The package builds without errors for an iOS Simulator.
- [x] `packages.json` remains sorted alphabetically.