### PR TITLE
Add https://github.com/iheanyi/swift-palettecolor.git

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4431,6 +4431,7 @@
   "https://github.com/igorcamilo/tmdb-swift.git",
   "https://github.com/igormuzyka/phase.git",
   "https://github.com/ihar-shalouski/swift-vector-and-matrix.git",
+  "https://github.com/iheanyi/swift-palettecolor.git",
   "https://github.com/IhorIlin/CoreDataService.git",
   "https://github.com/iKenndac/localized-strings-symbols.git",
   "https://github.com/ikesyo/Himotoki.git",


### PR DESCRIPTION
Adds [swift-palettecolor](https://github.com/iheanyi/swift-palettecolor) — Swift Package Manager library (`PaletteColor`) porting AndroidX Palette extraction + contrast helpers. Apache-2.0. Tagged `0.1.0`.