### PR TITLE
Add loudkit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5831,6 +5831,7 @@
   "https://github.com/lostatseajoshua/SwiftExpression.git",
   "https://github.com/LottieFiles/dotlottie-ios.git",
   "https://github.com/loudmouth/Interstellar.git",
+  "https://github.com/loudreader/loudkit.git",
   "https://github.com/Loupehope/DylibForge.git",
   "https://github.com/lovetodream/ohje.git",
   "https://github.com/lovetodream/oracle-nio.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [LoudKit](https://github.com/loudreader/loudkit)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.

LoudKit is the Swift SDK of loudkit, an on-device text-to-speech engine (Apache-2.0). The package lives at the root of a monorepo; `swift package dump-package` reports two library products, `LoudKit` and `LoudKitText`, tools version 5.9, platforms macOS 14 and iOS 17. The latest semantic-version tag is `v0.1.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
