### PR TITLE
Add unionst/swift-chat

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -10780,6 +10780,7 @@
   "https://github.com/UnGast/swim.git",
   "https://github.com/unibas-medfak/NiftyRSA.git",
   "https://github.com/unibrix/SwiftHorizontalRuler.git",
+  "https://github.com/unionst/swift-chat.git",
   "https://github.com/unissey/sdk-ios.git",
   "https://github.com/unixpickle/coreml-builder.git",
   "https://github.com/unixpickle/honeycrisp.git",


### PR DESCRIPTION
Adds https://github.com/unionst/swift-chat.git, an iMessage-faithful chat UI package for SwiftUI (iOS 18+), formerly published as union-chat. Binary xcframework target with a public release asset; `swift package dump-package` succeeds.