### PR TITLE
Add Ollin

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2922,6 +2922,7 @@
   "https://github.com/dziobaczy/SwiftBuilderMacro.git",
   "https://github.com/eansearch/UPCBarcodeLookup.git",
   "https://github.com/eastriverlee/LLM.swift.git",
+  "https://github.com/eaviles/Ollin.git",
   "https://github.com/eBardX/XestiMonitors.git",
   "https://github.com/eBay/NautilusTelemetry.git",
   "https://github.com/eclipse-biscuit/biscuit-swift.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [Ollin](https://github.com/eaviles/Ollin)

A creative-coding framework for Swift and Metal on Apple platforms: a sketch is a class with `setup()` and `draw()`, drawn by Metal in linear light, with live reload, shaders and effects, 3D, physics, audio, computer vision, and video, print and pen-plotter export. MIT, `.spi.yml` included so the index can build documentation for its twenty-two library modules.

## Checklist

I have either:

* [x] Run `swift ./validate.swift`. It reported this as the one addition, verified it, and left `packages.json` untouched.

Or, checked that:

* [x] The package repositories are publicly accessible.
* [x] The packages all contain a `Package.swift` file in the root folder.
* [x] The packages are written in Swift 5.0 or later.
* [x] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [x] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [x] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [x] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [x] The packages all compile without errors.
* [x] The package list JSON file is sorted alphabetically.

One note for whoever reviews this: the package is Apple-only by design (Metal, AppKit, and the Apple media frameworks), with a floor of macOS 26 and Swift 6.3, so the Linux, Android and WebAssembly rows of the compatibility matrix will not build. That is expected rather than a fault in the submission.
